### PR TITLE
Update build-project.yaml

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -96,7 +96,7 @@ jobs:
     defaults:
       run:
         shell: zsh --no-rcs --errexit --pipefail {0}
-    if: ${{ inputs.release == false }}
+    if: ${{ inputs.production == false }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -201,7 +201,7 @@ jobs:
     defaults:
       run:
         shell: zsh --no-rcs --errexit --pipefail {0}
-    if: ${{ inputs.release == true }}
+    if: ${{ inputs.production == true }}
     environment: production
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the workflow conditions in `.github/workflows/build-project.yaml` to use the `production` input instead of `release`. This change clarifies the intent of the workflow triggers and aligns them with the correct environment.

Workflow condition updates:

* Changed the workflow condition from `inputs.release` to `inputs.production` for both the non-production and production jobs in `.github/workflows/build-project.yaml`. [[1]](diffhunk://#diff-58a222b2569531e3ee88d373cb6b2a3b0e4d1b24ebd09ba9d03e12b6f110bb03L99-R99) [[2]](diffhunk://#diff-58a222b2569531e3ee88d373cb6b2a3b0e4d1b24ebd09ba9d03e12b6f110bb03L204-R204)