### PR TITLE
Dither

### DIFF
--- a/data/effects/main.effect
+++ b/data/effects/main.effect
@@ -27,12 +27,25 @@ float4 PSDraw(VertInOut vert_in) : TARGET
 	return image.Sample(def_sampler, vert_in.uv);
 }
 
+float random(float2 p)
+{
+	float3 p3 = frac(p.xyx * float3(443.897, 441.423, 437.195));
+	p3 += dot(p3, p3.yzx + 19.19);
+	return frac((p3.x + p3.y) * p3.z);
+}
+
 float4 PSDrawWithMask(VertInOut vert_in) : TARGET
 {
 	float2 uv = vert_in.uv;
 	float4 final_color;
+
 	final_color.rgb = image.Sample(def_sampler, uv).rgb;
-	final_color.a = mask.Sample(def_sampler, vert_in.uv).r;
+
+	float mask_alpha = mask.Sample(def_sampler, uv).r;
+	float threshold = random(uv);
+
+	final_color.a = step(threshold, mask_alpha);
+
 	return final_color;
 }
 


### PR DESCRIPTION
This pull request updates the alpha masking technique in the `PSDrawWithMask` shader function to use stochastic (randomized) alpha testing, which can help reduce aliasing artifacts and create smoother mask edges. The main change introduces a `random` function and applies it per-pixel to determine the alpha value.

**Shader improvements:**

* Added a `random` function to generate a pseudo-random value based on UV coordinates, enabling stochastic effects in the shader.
* Updated the alpha calculation in `PSDrawWithMask` to use the new random threshold, replacing direct sampling with a step function for stochastic alpha masking.