### PR TITLE
Add wolfssl overlay port and update dependencies

### DIFF
--- a/vcpkg-overlay-ports/wolfssl/portfile.cmake
+++ b/vcpkg-overlay-ports/wolfssl/portfile.cmake
@@ -1,0 +1,51 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO wolfssl/wolfssl
+    REF "v${VERSION}-stable"
+    SHA512 29f52644966f21908e0d3f795c62b0f5af9cd2d766db20c6ed5c588611f19f048119827fe6e787ccc3ce676d8c97cf7ab409d996df0e3acb812d6cd01364de61
+    HEAD_REF master
+    PATCHES
+)
+
+vcpkg_cmake_get_vars(cmake_vars_file)
+include("${cmake_vars_file}")
+
+set(LOCAL_C_FLAGS_RELEASE "${VCPKG_COMBINED_C_FLAGS_RELEASE}")
+set(LOCAL_C_FLAGS_DEBUG "${VCPKG_COMBINED_C_FLAGS_DEBUG}")
+
+if(VCPKG_TARGET_IS_LINUX)
+  message(STATUS "Applying workaround for wolfSSL stringop-overflow warning on Linux.")
+  set(LOCAL_C_FLAGS_RELEASE "${LOCAL_C_FLAGS_RELEASE} -Wno-error=stringop-overflow")
+  set(LOCAL_C_FLAGS_DEBUG "${LOCAL_C_FLAGS_DEBUG} -Wno-error=stringop-overflow")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+      -DWOLFSSL_BUILD_OUT_OF_TREE=yes
+      -DWOLFSSL_EXAMPLES=no
+      -DWOLFSSL_CRYPT_TESTS=no
+      -DWOLFSSL_CURL=yes
+    OPTIONS_RELEASE
+      -DCMAKE_C_FLAGS=${LOCAL_C_FLAGS_RELEASE}
+    OPTIONS_DEBUG
+      -DCMAKE_C_FLAGS=${LOCAL_C_FLAGS_DEBUG}
+      -DWOLFSSL_DEBUG=yes
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/wolfssl)
+
+if(VCPKG_TARGET_IS_IOS OR VCPKG_TARGET_IS_OSX)
+  vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/wolfssl.pc" "Libs.private: " "Libs.private: -framework CoreFoundation -framework Security ")
+  if(NOT VCPKG_BUILD_TYPE)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/wolfssl.pc" "Libs.private: " "Libs.private: -framework CoreFoundation -framework Security ")
+  endif()
+endif()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/vcpkg-overlay-ports/wolfssl/vcpkg.json
+++ b/vcpkg-overlay-ports/wolfssl/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "wolfssl",
+  "version": "5.8.2",
+  "description": "TLS and Cryptographic library for many platforms",
+  "homepage": "https://wolfssl.com",
+  "license": "GPL-3.0-or-later",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,6 +9,17 @@
         "png"
       ]
     },
-    "ncnn"
+    "ncnn",
+    {
+      "name": "curl",
+      "default-features": false,
+      "features": [
+        "wolfssl"
+      ]
+    },
+    {
+      "name": "cpr",
+      "default-features": false
+    }
   ]
 }


### PR DESCRIPTION
This pull request adds support for building the `curl` and `cpr` libraries with the `wolfssl` backend by introducing a custom port for `wolfssl` and updating the dependency configuration. The changes ensure that `curl` is built without default features but with `wolfssl` support, and that all necessary build tools and patches are included for a smooth integration.

Dependency and build system updates:

* Added a custom `wolfssl` port under `vcpkg-overlay-ports/wolfssl`, including a `portfile.cmake` that fetches the source, configures build options (e.g., disables examples/tests, enables curl support), applies platform-specific compiler flags, and handles installation and packaging details.
* Created a `vcpkg.json` manifest for the new `wolfssl` port, specifying its version, metadata, supported platforms, and build tool dependencies.

Project dependency configuration:

* Updated the main `vcpkg.json` to add `curl` (with `wolfssl` feature and no default features) and `cpr` (with no default features) as dependencies, ensuring they use the new `wolfssl` backend.Introduces a custom overlay port for wolfssl with a portfile and vcpkg.json. Updates the main vcpkg.json to add curl (with wolfssl feature) and cpr as dependencies, enabling wolfssl-based TLS support.