### PR TITLE
Update my-testing.yaml

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -119,14 +119,17 @@ jobs:
       - name: Install mono
         run: brew install mono
 
-      - name: Setup NuGet Credentials
+      - name: "Setup NuGet Credentials"
         run: |
-          mono "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n1)" sources add \
+          NUGET_PATH="$($VCPKG_ROOT/vcpkg fetch nuget | tail -n1)"
+          mono "$NUGET_PATH" sources add \
             -Source "https://nuget.pkg.github.com/kaito-tokyo/index.json" \
             -StorePasswordInClearText \
             -Name "GitHub" \
             -UserName "kaito-tokyo" \
             -Password "${{ secrets.GITHUB_TOKEN }}"
+          mono "$NUGET_PATH" setapikey "${{ secrets.GITHUB_TOKEN }}" \
+            -Source "https://nuget.pkg.github.com/kaito-tokyo/index.json"
 
       - name: Set Up Environment 🔧
         id: setup
@@ -250,14 +253,17 @@ jobs:
       - name: Install mono
         run: brew install mono
 
-      - name: Setup NuGet Credentials
+      - name: "Setup NuGet Credentials"
         run: |
-          mono "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n1)" sources add \
+          NUGET_PATH="$($VCPKG_ROOT/vcpkg fetch nuget | tail -n1)"
+          mono "$NUGET_PATH" sources add \
             -Source "https://nuget.pkg.github.com/kaito-tokyo/index.json" \
             -StorePasswordInClearText \
             -Name "GitHub" \
             -UserName "kaito-tokyo" \
             -Password "${{ secrets.GITHUB_TOKEN }}"
+          mono "$NUGET_PATH" setapikey "${{ secrets.GITHUB_TOKEN }}" \
+            -Source "https://nuget.pkg.github.com/kaito-tokyo/index.json"
 
       - name: Set Up Environment 🔧
         id: setup
@@ -382,14 +388,17 @@ jobs:
       - name: Install mono
         run: sudo apt-get -y install mono-devel
 
-      - name: Setup NuGet Credentials
+      - name: "Setup NuGet Credentials"
         run: |
-          mono "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n1)" sources add \
+          NUGET_PATH="$($VCPKG_ROOT/vcpkg fetch nuget | tail -n1)"
+          mono "$NUGET_PATH" sources add \
             -Source "https://nuget.pkg.github.com/kaito-tokyo/index.json" \
             -StorePasswordInClearText \
             -Name "GitHub" \
             -UserName "kaito-tokyo" \
             -Password "${{ secrets.GITHUB_TOKEN }}"
+          mono "$NUGET_PATH" setapikey "${{ secrets.GITHUB_TOKEN }}" \
+            -Source "https://nuget.pkg.github.com/kaito-tokyo/index.json"
 
       - name: Set Up Environment 🔧
         id: setup
@@ -477,7 +486,7 @@ jobs:
         run: |
           .\bootstrap-vcpkg.bat
 
-      - name: "Setup NuGet Credentials"
+      - name: "Setup NuGet Credentials on Windows"
         shell: pwsh
         run: |
           $NUGET_EXE_PATH = & "${{ env.VCPKG_ROOT }}/vcpkg" fetch nuget | Select-Object -Last 1

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -497,6 +497,8 @@ jobs:
             -Name "GitHub" `
             -UserName "kaito-tokyo" `
             -Password "${{ secrets.GITHUB_TOKEN }}"
+          & $NUGET_EXE_PATH setapikey "${{ secrets.GITHUB_TOKEN }}" `
+            -Source "https://nuget.pkg.github.com/kaito-tokyo/index.json"
 
       - name: Set Up Environment 🔧
         id: setup

--- a/.github/workflows/my-testing.yaml
+++ b/.github/workflows/my-testing.yaml
@@ -103,6 +103,8 @@ jobs:
             -Name "GitHub" `
             -UserName "kaito-tokyo" `
             -Password "${{ secrets.GITHUB_TOKEN }}"
+          & $NUGET_EXE_PATH setapikey "${{ secrets.GITHUB_TOKEN }}" `
+            -Source "https://nuget.pkg.github.com/kaito-tokyo/index.json"
 
       - name: "Configure"
         run: "cmake --preset windows-testing-ci-x64"
@@ -145,6 +147,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             build-essential \
             libgles2-mesa-dev \
+            obs-studio \
             qt6-base-dev \
             libqt6svg6-dev \
             qt6-base-private-dev \

--- a/.github/workflows/my-testing.yaml
+++ b/.github/workflows/my-testing.yaml
@@ -21,24 +21,10 @@ permissions:
   packages: "write"
 
 jobs:
-  RunTests:
-    name: "Run Tests on ${{ matrix.os-name }}"
-    strategy:
-      matrix:
-        include:
-          - os: macos-15
-            os-name: macOS
-            preset: macos-testing-ci
-          - os: windows-2022
-            os-name: Windows
-            preset: windows-testing-ci-x64
-          - os: ubuntu-24.04
-            os-name: Ubuntu
-            preset: ubuntu-testing-ci-x86_64
-      fail-fast: false
-
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+  TestOnMacOS:
+    name: "Run Tests on macOS"
+    runs-on: "macos-15"
+    timeout-minutes: 60
 
     env:
       VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/kaito-tokyo/index.json,readwrite"
@@ -55,49 +41,56 @@ jobs:
           path: "${{ env.VCPKG_ROOT }}"
 
       - name: "Bootstrap vcpkg"
-        if: runner.os != 'Windows'
         working-directory: "${{ env.VCPKG_ROOT }}"
-        run: |
-          cd "${{ env.VCPKG_ROOT }}"
-          ./bootstrap-vcpkg.sh
+        run: ./bootstrap-vcpkg.sh
 
-      - name: "Bootstrap vcpkg (Windows)"
-        if: runner.os == 'Windows'
+      - name: "Install mono"
+        run: brew install mono
+
+      - name: "Setup NuGet Credentials"
+        run: |
+          NUGET_PATH="$($VCPKG_ROOT/vcpkg fetch nuget | tail -n1)"
+          mono "$NUGET_PATH" sources add \
+            -Source "https://nuget.pkg.github.com/kaito-tokyo/index.json" \
+            -StorePasswordInClearText \
+            -Name "GitHub" \
+            -UserName "kaito-tokyo" \
+            -Password "${{ secrets.GITHUB_TOKEN }}"
+          mono "$NUGET_PATH" setapikey "${{ secrets.GITHUB_TOKEN }}" \
+            -Source "https://nuget.pkg.github.com/kaito-tokyo/index.json"
+
+      - name: "Configure"
+        run: "cmake --preset macos-testing-ci"
+        
+      - name: "Build"
+        run: "cmake --build --preset macos-testing-ci"
+        
+      - name: "Run tests"
+        run: "ctest --preset macos-testing-ci --verbose"
+
+  TestOnWindows:
+    name: "Run Tests on Windows"
+    runs-on: "windows-2022"
+    timeout-minutes: 60
+
+    env:
+      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/kaito-tokyo/index.json,readwrite"
+      VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v5"
+
+      - name: "Checkout vcpkg repository"
+        uses: "actions/checkout@v5"
+        with:
+          repository: "microsoft/vcpkg"
+          path: "${{ env.VCPKG_ROOT }}"
+
+      - name: "Bootstrap vcpkg"
         working-directory: "${{ env.VCPKG_ROOT }}"
         shell: "pwsh"
-        run: |
-          cd "${{ env.VCPKG_ROOT }}"
-          .\bootstrap-vcpkg.bat
-
-      - name: "Setup .NET"
-        uses: "actions/setup-dotnet@v4"
-        with:
-          dotnet-version: '8.0.x'
-
-      - name: "Install dependencies on macOS"
-        if: runner.os == 'macOS'
-        run: |
-          brew install mono
-
-      - name: "Install dependencies on Ubuntu"
-        if: runner.os == 'Linux'
-        run: |
-          echo "man-db man-db/auto-update boolean false" | sudo debconf-set-selections
-          sudo apt-get remove --purge -y man-db
-          sudo add-apt-repository -y ppa:obsproject/obs-studio
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libgles2-mesa-dev \
-            obs-studio \
-            qt6-base-dev \
-            libqt6svg6-dev \
-            qt6-base-private-dev \
-            cmake \
-            git \
-            jq \
-            ninja-build \
-            pkg-config \
-            mono-devel
+        run: ".\\bootstrap-vcpkg.bat"
 
       - name: "Setup NuGet Credentials on Windows"
         shell: pwsh
@@ -111,21 +104,74 @@ jobs:
             -UserName "kaito-tokyo" `
             -Password "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: "Setup NuGet Credentials on macOS / Linux"
-        if: runner.os != 'Windows'
+      - name: "Configure"
+        run: "cmake --preset windows-testing-ci-x64"
+
+      - name: "Build"
+        run: "cmake --build --preset windows-testing-ci-x64"
+        
+      - name: "Run tests"
+        run: "ctest --preset windows-testing-ci-x64 --verbose"
+
+  TestOnUbuntu:
+    name: "Run Tests on Ubuntu"
+    runs-on: "ubuntu-24.04"
+    timeout-minutes: 60
+
+    env:
+      VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/kaito-tokyo/index.json,readwrite"
+      VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v5"
+
+      - name: "Checkout vcpkg repository"
+        uses: "actions/checkout@v5"
+        with:
+          repository: "microsoft/vcpkg"
+          path: "${{ env.VCPKG_ROOT }}"
+
+      - name: "Bootstrap vcpkg"
+        working-directory: "${{ env.VCPKG_ROOT }}"
+        run: "./bootstrap-vcpkg.sh"
+
+      - name: "Install dependencies on Ubuntu"
         run: |
-          mono "$($VCPKG_ROOT/vcpkg fetch nuget | tail -n1)" sources add \
+          echo "man-db man-db/auto-update boolean false" | sudo debconf-set-selections
+          sudo apt-get remove --purge -y man-db
+          sudo add-apt-repository -y ppa:obsproject/obs-studio
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            libgles2-mesa-dev \
+            qt6-base-dev \
+            libqt6svg6-dev \
+            qt6-base-private-dev \
+            cmake \
+            git \
+            jq \
+            ninja-build \
+            pkg-config \
+            mono-devel
+
+      - name: "Setup NuGet Credentials"
+        run: |
+          NUGET_PATH="$($VCPKG_ROOT/vcpkg fetch nuget | tail -n1)"
+          mono "$NUGET_PATH" sources add \
             -Source "https://nuget.pkg.github.com/kaito-tokyo/index.json" \
             -StorePasswordInClearText \
             -Name "GitHub" \
             -UserName "kaito-tokyo" \
             -Password "${{ secrets.GITHUB_TOKEN }}"
+          mono "$NUGET_PATH" setapikey "${{ secrets.GITHUB_TOKEN }}" \
+            -Source "https://nuget.pkg.github.com/kaito-tokyo/index.json"
 
       - name: "Configure"
-        run: "cmake --preset ${{ matrix.preset }}"
+        run: "cmake --preset ubuntu-testing-ci-x86_64"
 
       - name: "Build"
-        run: "cmake --build --preset ${{ matrix.preset }}"
+        run: "cmake --build --preset ubuntu-testing-ci-x86_64"
         
       - name: "Run tests"
-        run: "ctest --preset ${{ matrix.preset }} --verbose"
+        run: "ctest --preset ubuntu-testing-ci-x86_64 --verbose"


### PR DESCRIPTION
This pull request restructures the GitHub Actions workflow in `.github/workflows/my-testing.yaml` to split the testing process into separate jobs for macOS, Windows, and Ubuntu, and streamlines the setup steps for each environment. The changes improve maintainability, increase the timeout for each job, and ensure consistent setup and credential management across platforms.

**Workflow restructuring and parallelization:**

* Replaces the single matrix-based `RunTests` job with three distinct jobs: `TestOnMacOS`, `TestOnWindows`, and `TestOnUbuntu`, each targeting a specific OS and increasing the timeout to 60 minutes for better reliability.

**Platform-specific setup improvements:**

* Refactors the vcpkg bootstrapping and NuGet credential setup to be platform-appropriate, using `mono` on macOS/Linux and PowerShell on Windows, and consolidates credential steps for clarity and consistency. [[1]](diffhunk://#diff-869501959e8df31899edc97e86a54cfe980435783553606f60a82607df960f92L58-L91) [[2]](diffhunk://#diff-869501959e8df31899edc97e86a54cfe980435783553606f60a82607df960f92L102-R177)

**Build and test process standardization:**

* Standardizes the build and test steps for each platform using explicit CMake presets, ensuring each environment is configured, built, and tested in a consistent manner. [[1]](diffhunk://#diff-869501959e8df31899edc97e86a54cfe980435783553606f60a82607df960f92L58-L91) [[2]](diffhunk://#diff-869501959e8df31899edc97e86a54cfe980435783553606f60a82607df960f92L102-R177)

**Dependency installation updates:**

* Updates dependency installation commands, such as adding `build-essential` on Ubuntu, and ensures required tools like `mono` are installed on macOS.

**Cleanup and removal of redundant steps:**

* Removes obsolete or redundant steps, such as the previous matrix configuration, unnecessary conditionals, and duplicate credential setup, simplifying the workflow file. [[1]](diffhunk://#diff-869501959e8df31899edc97e86a54cfe980435783553606f60a82607df960f92L24-R27) [[2]](diffhunk://#diff-869501959e8df31899edc97e86a54cfe980435783553606f60a82607df960f92L102-R177)