### PR TITLE
Add startup method to MainPluginContext and log update info

### DIFF
--- a/src/MainPluginContext.cpp
+++ b/src/MainPluginContext.cpp
@@ -62,6 +62,10 @@ MainPluginContext::MainPluginContext(obs_data_t *_settings, obs_source_t *_sourc
 	  selfieSegmenterTaskQueue(std::make_unique<TaskQueue>(logger)),
 	  updateChecker(logger)
 {
+}
+
+void MainPluginContext::startup() noexcept
+{
 	futureLatestVersion = std::async(std::launch::async, [self = weak_from_this()]() -> std::optional<std::string> {
 		if (auto s = self.lock()) {
 			return s.get()->updateChecker.fetch();
@@ -305,6 +309,7 @@ void *main_plugin_context_create(obs_data_t *settings, obs_source_t *source)
 try {
 	graphics_context_guard guard;
 	auto self = std::make_shared<MainPluginContext>(settings, source);
+	self->startup();
 	return new std::shared_ptr<MainPluginContext>(self);
 } catch (const std::exception &e) {
 	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to create main plugin context: %s", e.what());

--- a/src/MainPluginContext.h
+++ b/src/MainPluginContext.h
@@ -53,6 +53,7 @@ namespace obs_backgroundremoval_lite {
 class MainPluginContext : public std::enable_shared_from_this<MainPluginContext> {
 public:
 	MainPluginContext(obs_data_t *settings, obs_source_t *source);
+	void startup() noexcept;
 	~MainPluginContext() noexcept;
 	void shutdown() noexcept;
 

--- a/src/UpdateChecker/UpdateChecker.hpp
+++ b/src/UpdateChecker/UpdateChecker.hpp
@@ -55,6 +55,7 @@ public:
 		cpr::Response r = session.Get();
 
 		if (r.status_code == 200) {
+			logger.info("Fetched latest version information: {}", r.text);
 			return {r.text};
 		} else {
 			logger.warn("Failed to fetch latest version information: HTTP {}", r.status_code);


### PR DESCRIPTION
This pull request refactors the initialization flow of the `MainPluginContext` by moving asynchronous startup logic into a dedicated method, and improves logging for update checks. The changes enhance code clarity and maintainability by separating construction from startup tasks and providing better visibility into update operations.

**Initialization refactor:**

* Added a new `startup()` method to `MainPluginContext`, moving asynchronous startup logic out of the constructor for clearer separation of concerns (`src/MainPluginContext.cpp`, `src/MainPluginContext.h`). [[1]](diffhunk://#diff-2d840159c3cd8f3bbc7cd26789596da8edde2415b7376f8de3d92403e91be39bR64-R67) [[2]](diffhunk://#diff-dd6f478e1ff846c44f174b36817a5bcddcc19c6eb10f58501e6d8f144e74c4b7R56)
* Updated `main_plugin_context_create` to call the new `startup()` method after constructing `MainPluginContext` (`src/MainPluginContext.cpp`).

**Logging improvements:**

* Added an info log message to record the full response text when successfully fetching the latest version information in `UpdateChecker` (`src/UpdateChecker/UpdateChecker.hpp`).Introduces a startup() method in MainPluginContext to handle asynchronous initialization, now called during context creation. Also adds logging of fetched version information in UpdateChecker for improved diagnostics.