### PR TITLE
Use default number of threads

### DIFF
--- a/src/SelfieSegmenter.hpp
+++ b/src/SelfieSegmenter.hpp
@@ -51,7 +51,6 @@ public:
 		if (net.load_model(bin_path.get()) != 0) {
 			throw std::runtime_error(std::string("Failed to load ncnn bin file: ") + bin_path.get());
 		}
-		net.opt.num_threads = 1;
 	}
 
 	void run(const ncnn::Mat &input, ncnn::Mat &output) const


### PR DESCRIPTION
This pull request makes a minor update to the `NcnnInferenceEngine` class in `SelfieSegmenter.hpp`. The number of threads used by the `net` object is no longer explicitly set to 1, allowing it to use the default threading behavior.

- Removed the line that set `net.opt.num_threads = 1`, so the number of threads will now be determined by the default configuration.