### PR TITLE
Refactor mask texture handling in videoRender

### DIFF
--- a/src/MainPluginContext.cpp
+++ b/src/MainPluginContext.cpp
@@ -227,8 +227,8 @@ void MainPluginContext::videoRender()
 	cv::resize(croppedMask, dstMask, dstMask.size(), 0, 0, cv::INTER_NEAREST);
 
 	const std::uint8_t *r8Data = scaledMaskData.data();
-	unique_gs_texture_t maskTexture = make_unique_gs_texture(width, height, GS_R8, 1, &r8Data, 0);
-	mainEffect.drawWithMask(width, height, bgrxSourceInput.get(), maskTexture.get());
+	gs_texture_set_image(r8Mask.get(), r8Data, width, 0);
+	mainEffect.drawWithMask(width, height, bgrxSourceInput.get(), r8Mask.get());
 
 	if (readerSegmenterInput && bgrxSegmenterInput) {
 		readerSegmenterInput->stage(bgrxSegmenterInput.get());
@@ -279,6 +279,7 @@ void MainPluginContext::ensureTextures()
 	ensureTexture(bgrxSourceInput, width, height, GS_BGRX, GS_RENDER_TARGET);
 	ensureTexture(bgrxSegmenterInput, SelfieSegmenter::INPUT_WIDTH, SelfieSegmenter::INPUT_HEIGHT, GS_BGRX,
 		      GS_RENDER_TARGET);
+	ensureTexture(r8Mask, width, height, GS_R8, GS_DYNAMIC);
 	ensureTextureReader(readerSegmenterInput, SelfieSegmenter::INPUT_WIDTH, SelfieSegmenter::INPUT_HEIGHT, GS_BGRX);
 }
 

--- a/src/MainPluginContext.h
+++ b/src/MainPluginContext.h
@@ -92,6 +92,7 @@ private:
 
 	kaito_tokyo::obs_bridge_utils::unique_gs_texture_t bgrxSourceInput = nullptr;
 	kaito_tokyo::obs_bridge_utils::unique_gs_texture_t bgrxSegmenterInput = nullptr;
+	kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r8Mask = nullptr;
 
 	std::vector<std::uint8_t> scaledMaskData;
 


### PR DESCRIPTION
This pull request updates the mask texture management in the video rendering pipeline to improve performance and resource handling. The main change is switching from creating a new mask texture each frame to reusing and updating an existing dynamic texture. This should reduce overhead and improve efficiency.

**Texture management improvements:**

* Added a persistent `r8Mask` texture as a member of `MainPluginContext` to avoid recreating the mask texture every frame.
* Ensured the `r8Mask` texture is created with the correct size and format in `ensureTextures()` using the `GS_DYNAMIC` flag for efficient updates.

**Rendering pipeline changes:**

* Updated `videoRender()` to use `gs_texture_set_image` to update the contents of the persistent `r8Mask` texture each frame, instead of creating a new texture, and passed it to `drawWithMask`.Replaces per-frame creation of maskTexture with persistent r8Mask texture, updating its image data each frame. Adds r8Mask member and ensures its initialization in ensureTextures for improved performance and resource management.