### PR TITLE
Rendering context

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ target_compile_definitions(
   PRIVATE PLUGIN_NAME="${CMAKE_PROJECT_NAME}" PLUGIN_VERSION="${CMAKE_PROJECT_VERSION}"
 )
 
-target_sources(${CMAKE_PROJECT_NAME} PRIVATE src/MainPluginContext_c.cpp src/MainPluginContext.cpp src/plugin-main.c)
+target_sources(${CMAKE_PROJECT_NAME} PRIVATE src/MainPluginContext_c.cpp src/MainPluginContext.cpp src/RenderingContext.cpp src/plugin-main.c)
 target_link_libraries(
   ${CMAKE_PROJECT_NAME}
   PUBLIC OBS::libobs cpr::cpr Eigen3::Eigen fmt::fmt ncnn opencv_core opencv_imgproc opencv_imgcodecs semver::semver

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,10 @@ target_compile_definitions(
   PRIVATE PLUGIN_NAME="${CMAKE_PROJECT_NAME}" PLUGIN_VERSION="${CMAKE_PROJECT_VERSION}"
 )
 
-target_sources(${CMAKE_PROJECT_NAME} PRIVATE src/MainPluginContext_c.cpp src/MainPluginContext.cpp src/RenderingContext.cpp src/plugin-main.c)
+target_sources(
+  ${CMAKE_PROJECT_NAME}
+  PRIVATE src/MainPluginContext_c.cpp src/MainPluginContext.cpp src/RenderingContext.cpp src/plugin-main.c
+)
 target_link_libraries(
   ${CMAKE_PROJECT_NAME}
   PUBLIC OBS::libobs cpr::cpr Eigen3::Eigen fmt::fmt ncnn opencv_core opencv_imgproc opencv_imgcodecs semver::semver

--- a/src/MainEffect.hpp
+++ b/src/MainEffect.hpp
@@ -31,30 +31,6 @@ namespace obs_backgroundremoval_lite {
 
 namespace main_effect_detail {
 
-struct RenderingGuard {
-	gs_texture_t *previousRenderTarget;
-	gs_zstencil_t *previousZStencil;
-	gs_color_space previousColorSpace;
-
-	RenderingGuard(gs_texture_t *targetTexture, gs_blend_type srcBlendType = GS_BLEND_ONE,
-		       gs_blend_type dstBlendType = GS_BLEND_ZERO, gs_zstencil_t *targetZStencil = nullptr,
-		       gs_color_space targetColorSpace = GS_CS_SRGB)
-		: previousRenderTarget(gs_get_render_target()),
-		  previousZStencil(gs_get_zstencil_target()),
-		  previousColorSpace(gs_get_color_space())
-	{
-		gs_set_render_target_with_color_space(targetTexture, targetZStencil, targetColorSpace);
-		gs_blend_state_push();
-		gs_blend_function(srcBlendType, dstBlendType);
-	}
-
-	~RenderingGuard()
-	{
-		gs_blend_state_pop();
-		gs_set_render_target_with_color_space(previousRenderTarget, previousZStencil, previousColorSpace);
-	}
-};
-
 inline gs_eparam_t *getEffectParam(const kaito_tokyo::obs_bridge_utils::unique_gs_effect_t &effect, const char *name,
 				   const kaito_tokyo::obs_bridge_utils::ILogger &logger)
 {
@@ -108,7 +84,7 @@ public:
 	gs_technique_t *const techDraw;
 	gs_technique_t *const techDrawWithMask;
 
-	void draw(std::uint32_t width, std::uint32_t height, gs_texture_t *sourceTexture) noexcept
+	void draw(std::uint32_t width, std::uint32_t height, gs_texture_t *sourceTexture) const noexcept
 	{
 		gs_technique_t *tech = techDraw;
 		std::size_t passes = gs_technique_begin(tech);
@@ -124,7 +100,7 @@ public:
 	}
 
 	void drawWithMask(std::uint32_t width, std::uint32_t height, gs_texture_t *sourceTexture,
-			  gs_texture_t *maskTexture) noexcept
+			  gs_texture_t *maskTexture) const noexcept
 	{
 		gs_technique_t *tech = techDrawWithMask;
 		std::size_t passes = gs_technique_begin(tech);

--- a/src/MainPluginContext.cpp
+++ b/src/MainPluginContext.cpp
@@ -237,11 +237,8 @@ void MainPluginContext::videoRender()
 
 obs_source_frame *MainPluginContext::filterVideo(struct obs_source_frame *frame)
 {
-	if (width != frame->width || height != frame->height) {
-		width = frame->width;
-		height = frame->height;
-
-		ensureTextures();
+	if (renderingContext->width != frame->width || renderingContext->height != frame->height) {
+		renderingContext = std::make_unique<RenderingContext>(frame->width, frame->height, logger);
 	}
 
 	if (selfieSegmenterTaskQueue) {
@@ -272,15 +269,6 @@ obs_source_frame *MainPluginContext::filterVideo(struct obs_source_frame *frame)
 	}
 
 	return frame;
-}
-
-void MainPluginContext::ensureTextures()
-{
-	ensureTexture(bgrxSourceInput, width, height, GS_BGRX, GS_RENDER_TARGET);
-	ensureTexture(bgrxSegmenterInput, SelfieSegmenter::INPUT_WIDTH, SelfieSegmenter::INPUT_HEIGHT, GS_BGRX,
-		      GS_RENDER_TARGET);
-	ensureTexture(r8Mask, width, height, GS_R8, GS_DYNAMIC);
-	ensureTextureReader(readerSegmenterInput, SelfieSegmenter::INPUT_WIDTH, SelfieSegmenter::INPUT_HEIGHT, GS_BGRX);
 }
 
 std::optional<std::string> MainPluginContext::getLatestVersion() const

--- a/src/MainPluginContext.cpp
+++ b/src/MainPluginContext.cpp
@@ -33,7 +33,8 @@ MainPluginContext::MainPluginContext(obs_data_t *settings, obs_source_t *_source
 	: source{_source},
 	  logger("[" PLUGIN_NAME "] "),
 	  mainEffect(unique_obs_module_file("effects/main.effect"), logger),
-	  updateChecker(logger)
+	  updateChecker(logger),
+	  selfieSegmenterTaskQueue(logger, 1)
 {
 	unique_bfree_char_t paramPath = unique_obs_module_file("models/mediapipe_selfie_segmentation_int8.ncnn.param");
 	if (!paramPath) {
@@ -143,7 +144,8 @@ try {
 	if (!renderingContext || renderingContext->width != frame->width || renderingContext->height != frame->height) {
 		const graphics_context_guard guard;
 		renderingContext = std::make_unique<RenderingContext>(source, logger, mainEffect, selfieSegmenterNet,
-								      frame->width, frame->height);
+								      selfieSegmenterTaskQueue, frame->width,
+								      frame->height);
 	}
 
 	return frame;

--- a/src/MainPluginContext.cpp
+++ b/src/MainPluginContext.cpp
@@ -35,11 +35,11 @@ MainPluginContext::MainPluginContext(obs_data_t *settings, obs_source_t *_source
 	  mainEffect(unique_obs_module_file("effects/main.effect"), logger),
 	  updateChecker(logger)
 {
-	unique_bfree_char_t paramPath = unique_obs_module_file("models/selfie_segmentation_int8.ncnn.param");
+	unique_bfree_char_t paramPath = unique_obs_module_file("models/mediapipe_selfie_segmentation_int8.ncnn.param");
 	if (!paramPath) {
 		throw std::runtime_error("Failed to find model param file");
 	}
-	unique_bfree_char_t binPath = unique_obs_module_file("models/selfie_segmentation_int8.ncnn.bin");
+	unique_bfree_char_t binPath = unique_obs_module_file("models/mediapipe_selfie_segmentation_int8.ncnn.bin");
 	if (!binPath) {
 		throw std::runtime_error("Failed to find model bin file");
 	}

--- a/src/MainPluginContext.cpp
+++ b/src/MainPluginContext.cpp
@@ -88,6 +88,7 @@ obs_properties_t *MainPluginContext::getProperties()
 
 void MainPluginContext::update(obs_data_t *_settings)
 {
+	UNUSED_PARAMETER(_settings);
 }
 
 void MainPluginContext::activate() {}
@@ -122,7 +123,7 @@ void MainPluginContext::videoRender()
 obs_source_frame *MainPluginContext::filterVideo(struct obs_source_frame *frame)
 {
 	if (renderingContext->width != frame->width || renderingContext->height != frame->height) {
-		renderingContext = std::make_unique<RenderingContext>(frame->width, frame->height, logger);
+		renderingContext = std::make_unique<RenderingContext>(source, logger, mainEffect, frame->width, frame->height);
 	}
 
 	return renderingContext->filterVideo(frame);

--- a/src/MainPluginContext.h
+++ b/src/MainPluginContext.h
@@ -41,17 +41,28 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <obs-bridge-utils/ObsLogger.hpp>
 
 #include "RenderingContext.hpp"
-#include "AsyncTextureReader.hpp"
 #include "MainEffect.hpp"
 #include "MyCprSession.hpp"
 #include "SelfieSegmenter.hpp"
 #include "TaskQueue.hpp"
 #include "UpdateChecker/UpdateChecker.hpp"
+#include "SelfieSegmenter.hpp"
 
 namespace kaito_tokyo {
 namespace obs_backgroundremoval_lite {
 
 class MainPluginContext : public std::enable_shared_from_this<MainPluginContext> {
+private:
+	obs_source_t *const source = nullptr;
+	const kaito_tokyo::obs_bridge_utils::ObsLogger logger;
+	const MainEffect mainEffect;
+	UpdateChecker<MyCprSession> updateChecker;
+	ncnn::Net selfieSegmenterNet;
+
+	std::unique_ptr<RenderingContext> renderingContext = nullptr;
+	std::shared_future<std::optional<std::string>> futureLatestVersion;
+	std::optional<std::string> getLatestVersion() const;
+
 public:
 	MainPluginContext(obs_data_t *settings, obs_source_t *source);
 	void startup() noexcept;
@@ -75,18 +86,6 @@ public:
 	obs_source_frame *filterVideo(obs_source_frame *frame);
 
 	const kaito_tokyo::obs_bridge_utils::ILogger &getLogger() const noexcept { return logger; }
-
-private:
-	obs_source_t *source = nullptr;
-	kaito_tokyo::obs_bridge_utils::ObsLogger logger;
-	MainEffect mainEffect;
-	UpdateChecker<MyCprSession> updateChecker;
-
-	std::unique_ptr<RenderingContext> renderingContext = nullptr;
-
-	std::shared_future<std::optional<std::string>> futureLatestVersion;
-
-	std::optional<std::string> getLatestVersion() const;
 };
 
 } // namespace obs_backgroundremoval_lite

--- a/src/MainPluginContext.h
+++ b/src/MainPluginContext.h
@@ -77,27 +77,16 @@ public:
 	const kaito_tokyo::obs_bridge_utils::ILogger &getLogger() const noexcept { return logger; }
 
 private:
-	obs_data_t *settings = nullptr;
 	obs_source_t *source = nullptr;
-
 	kaito_tokyo::obs_bridge_utils::ObsLogger logger;
 	MainEffect mainEffect;
-	SelfieSegmenter selfieSegmenter;
-	std::unique_ptr<TaskQueue> selfieSegmenterTaskQueue;
-	TaskQueue::CancellationToken selfieSegmenterPendingTaskToken;
-	std::mutex selfieSegmenterPendingTaskTokenMutex;
 	UpdateChecker<MyCprSession> updateChecker;
 
 	std::unique_ptr<RenderingContext> renderingContext = nullptr;
 
-	std::vector<std::uint8_t> scaledMaskData;
-
-	std::unique_ptr<AsyncTextureReader> readerSegmenterInput = nullptr;
-
 	std::shared_future<std::optional<std::string>> futureLatestVersion;
 
 	std::optional<std::string> getLatestVersion() const;
-	void ensureTextures();
 };
 
 } // namespace obs_backgroundremoval_lite

--- a/src/MainPluginContext.h
+++ b/src/MainPluginContext.h
@@ -40,6 +40,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include "obs-bridge-utils/gs_unique.hpp"
 #include <obs-bridge-utils/ObsLogger.hpp>
 
+#include "RenderingContext.hpp"
 #include "AsyncTextureReader.hpp"
 #include "MainEffect.hpp"
 #include "MyCprSession.hpp"
@@ -87,12 +88,7 @@ private:
 	std::mutex selfieSegmenterPendingTaskTokenMutex;
 	UpdateChecker<MyCprSession> updateChecker;
 
-	uint32_t width = 0;
-	uint32_t height = 0;
-
-	kaito_tokyo::obs_bridge_utils::unique_gs_texture_t bgrxSourceInput = nullptr;
-	kaito_tokyo::obs_bridge_utils::unique_gs_texture_t bgrxSegmenterInput = nullptr;
-	kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r8Mask = nullptr;
+	std::unique_ptr<RenderingContext> renderingContext = nullptr;
 
 	std::vector<std::uint8_t> scaledMaskData;
 

--- a/src/MainPluginContext.h
+++ b/src/MainPluginContext.h
@@ -37,16 +37,16 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include <net.h>
 
-#include "obs-bridge-utils/gs_unique.hpp"
+#include <obs-bridge-utils/gs_unique.hpp>
 #include <obs-bridge-utils/ObsLogger.hpp>
 
-#include "RenderingContext.hpp"
 #include "MainEffect.hpp"
 #include "MyCprSession.hpp"
+#include "RenderingContext.hpp"
 #include "SelfieSegmenter.hpp"
-#include "TaskQueue.hpp"
+#include "SelfieSegmenter.hpp"
+#include "ThrottledTaskQueue.hpp"
 #include "UpdateChecker/UpdateChecker.hpp"
-#include "SelfieSegmenter.hpp"
 
 namespace kaito_tokyo {
 namespace obs_backgroundremoval_lite {
@@ -57,6 +57,7 @@ private:
 	const kaito_tokyo::obs_bridge_utils::ObsLogger logger;
 	const MainEffect mainEffect;
 	UpdateChecker<MyCprSession> updateChecker;
+	ThrottledTaskQueue selfieSegmenterTaskQueue;
 	ncnn::Net selfieSegmenterNet;
 
 	std::unique_ptr<RenderingContext> renderingContext = nullptr;

--- a/src/RenderingContext.cpp
+++ b/src/RenderingContext.cpp
@@ -151,6 +151,8 @@ void RenderingContext::videoRender()
 		logger.error("Failed to sync texture reader: {}", e.what());
 	}
 
+	selfieSegmenter.process(readerSegmenterInput.getBuffer().data());
+
 	renderOriginalImage();
 	renderSegmenterInput();
 
@@ -165,7 +167,6 @@ void RenderingContext::videoRender()
 
 obs_source_frame *RenderingContext::filterVideo(obs_source_frame *frame)
 {
-	selfieSegmenter.process(readerSegmenterInput.getBuffer().data());
 	return frame;
 }
 

--- a/src/RenderingContext.cpp
+++ b/src/RenderingContext.cpp
@@ -1,0 +1,42 @@
+/*
+OBS Background Removal Lite
+Copyright (C) 2025 Kaito Udagawa umireon@kaito.tokyo
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>
+*/
+
+#include "RenderingContext.hpp"
+#include "SelfieSegmenter.hpp"
+
+using namespace kaito_tokyo::obs_bridge_utils;
+
+namespace kaito_tokyo {
+namespace obs_backgroundremoval_lite {
+
+RenderingContext::RenderingContext(std::uint32_t _width, std::uint32_t _height,
+                   const ILogger &_logger) noexcept
+    : width(_width), height(_height), logger(_logger),
+      bgrxOriginalImage(make_unique_gs_texture(width, height, GS_BGRX, 1, NULL, GS_RENDER_TARGET)),
+      bgrxSegmentorInput(make_unique_gs_texture(SelfieSegmenter::INPUT_WIDTH, SelfieSegmenter::INPUT_HEIGHT, GS_BGRX, 1, NULL, GS_RENDER_TARGET)),
+      r8SegmentationMask(make_unique_gs_texture(width, height, GS_R8, 1, NULL, GS_DYNAMIC)),
+      readerSegmenterInput(SelfieSegmenter::INPUT_WIDTH, SelfieSegmenter::INPUT_HEIGHT, GS_BGRX)
+{
+}
+
+RenderingContext::~RenderingContext() noexcept
+{
+}
+
+} // namespace obs_backgroundremoval_lite
+} // namespace kaito_tokyo

--- a/src/RenderingContext.cpp
+++ b/src/RenderingContext.cpp
@@ -159,8 +159,7 @@ void RenderingContext::videoRender()
 	const std::uint8_t *segmentationMaskData =
 		selfieSegmenter.getMask().data() + (maskRoiOffsetY * SelfieSegmenter::INPUT_WIDTH + maskRoiOffsetX);
 	gs_texture_set_image(r8SegmentationMask.get(), segmentationMaskData, SelfieSegmenter::INPUT_WIDTH, 0);
-	// mainEffect.drawWithMask(width, height, bgrxOriginalImage.get(), r8SegmentationMask.get());
-	mainEffect.draw(width, height, r8SegmentationMask.get());
+	mainEffect.drawWithMask(width, height, bgrxOriginalImage.get(), r8SegmentationMask.get());
 
 	readerSegmenterInput.stage(bgrxSegmenterInput.get());
 }

--- a/src/RenderingContext.cpp
+++ b/src/RenderingContext.cpp
@@ -103,7 +103,9 @@ RenderingContext::RenderingContext(obs_source_t *_source, const ILogger &_logger
 
 RenderingContext::~RenderingContext() noexcept {}
 
-void RenderingContext::videoTick(float seconds) {}
+void RenderingContext::videoTick(float seconds) {
+    UNUSED_PARAMETER(seconds);
+}
 
 void RenderingContext::renderOriginalImage()
 {

--- a/src/RenderingContext.cpp
+++ b/src/RenderingContext.cpp
@@ -16,26 +16,154 @@ You should have received a copy of the GNU General Public License along
 with this program. If not, see <https://www.gnu.org/licenses/>
 */
 
+#include <array>
+
 #include "RenderingContext.hpp"
 #include "SelfieSegmenter.hpp"
 
 using namespace kaito_tokyo::obs_bridge_utils;
 
+namespace {
+
+struct TransformStateGuard {
+	TransformStateGuard()
+	{
+		gs_viewport_push();
+		gs_projection_push();
+		gs_matrix_push();
+	}
+	~TransformStateGuard()
+	{
+		gs_matrix_pop();
+		gs_projection_pop();
+		gs_viewport_pop();
+	}
+};
+
+struct RenderTargetGuard {
+	gs_texture_t *previousRenderTarget;
+	gs_zstencil_t *previousZStencil;
+	gs_color_space previousColorSpace;
+
+	RenderTargetGuard()
+		: previousRenderTarget(gs_get_render_target()),
+		  previousZStencil(gs_get_zstencil_target()),
+		  previousColorSpace(gs_get_color_space())
+	{
+	}
+
+	~RenderTargetGuard()
+	{
+		gs_set_render_target_with_color_space(previousRenderTarget, previousZStencil, previousColorSpace);
+	}
+};
+
+std::array<std::uint32_t, 4> getMaskRoiDimension(std::uint32_t width, std::uint32_t height)
+{
+	using namespace kaito_tokyo::obs_backgroundremoval_lite;
+
+	double widthScale = static_cast<double>(SelfieSegmenter::INPUT_WIDTH) / static_cast<double>(width);
+	double heightScale = static_cast<double>(SelfieSegmenter::INPUT_HEIGHT) / static_cast<double>(height);
+	double scale = std::min(widthScale, heightScale);
+
+	std::uint32_t scaledWidth = static_cast<std::uint32_t>(std::round(width * scale));
+	std::uint32_t scaledHeight = static_cast<std::uint32_t>(std::round(height * scale));
+
+	std::uint32_t offsetX = (SelfieSegmenter::INPUT_WIDTH - scaledWidth) / 2;
+	std::uint32_t offsetY = (SelfieSegmenter::INPUT_HEIGHT - scaledHeight) / 2;
+
+	return {offsetX, offsetY, scaledWidth, scaledHeight};
+}
+
+} // anonymous namespace
+
 namespace kaito_tokyo {
 namespace obs_backgroundremoval_lite {
 
-RenderingContext::RenderingContext(std::uint32_t _width, std::uint32_t _height,
-                   const ILogger &_logger) noexcept
-    : width(_width), height(_height), logger(_logger),
-      bgrxOriginalImage(make_unique_gs_texture(width, height, GS_BGRX, 1, NULL, GS_RENDER_TARGET)),
-      bgrxSegmentorInput(make_unique_gs_texture(SelfieSegmenter::INPUT_WIDTH, SelfieSegmenter::INPUT_HEIGHT, GS_BGRX, 1, NULL, GS_RENDER_TARGET)),
-      r8SegmentationMask(make_unique_gs_texture(width, height, GS_R8, 1, NULL, GS_DYNAMIC)),
-      readerSegmenterInput(SelfieSegmenter::INPUT_WIDTH, SelfieSegmenter::INPUT_HEIGHT, GS_BGRX)
+RenderingContext::RenderingContext(obs_source_t *_source, const ILogger &_logger, const MainEffect &_mainEffect,
+				   std::uint32_t _width, std::uint32_t _height) noexcept
+	: source(_source),
+	  logger(_logger),
+	  mainEffect(_mainEffect),
+	  readerSegmenterInput(SelfieSegmenter::INPUT_WIDTH, SelfieSegmenter::INPUT_HEIGHT, GS_BGRX),
+	  selfieSegmenter(unique_obs_module_file("models/selfie_segmentation.param"),
+			  unique_obs_module_file("models/selfie_segmentation.bin")),
+	  width(_width),
+	  height(_height),
+	  bgrxOriginalImage(make_unique_gs_texture(width, height, GS_BGRX, 1, NULL, GS_RENDER_TARGET)),
+	  bgrxSegmentorInput(make_unique_gs_texture(SelfieSegmenter::INPUT_WIDTH, SelfieSegmenter::INPUT_HEIGHT,
+						    GS_BGRX, 1, NULL, GS_RENDER_TARGET)),
+	  maskRoiOffsetX(getMaskRoiDimension(width, height)[0]),
+	  maskRoiOffsetY(getMaskRoiDimension(width, height)[1]),
+	  maskRoiWidth(getMaskRoiDimension(width, height)[2]),
+	  maskRoiHeight(getMaskRoiDimension(width, height)[3]),
+	  r8SegmentationMask(make_unique_gs_texture(maskRoiWidth, maskRoiHeight, GS_R8, 1, NULL, GS_DYNAMIC))
 {
 }
 
-RenderingContext::~RenderingContext() noexcept
+RenderingContext::~RenderingContext() noexcept {}
+
+void RenderingContext::videoTick(float seconds) {}
+
+void RenderingContext::renderOriginalImage()
 {
+	RenderTargetGuard renderTargetGuard;
+	TransformStateGuard transformStateGuard;
+
+	gs_set_render_target_with_color_space(bgrxOriginalImage.get(), nullptr, GS_CS_SRGB);
+
+	if (!obs_source_process_filter_begin(source, GS_BGRA, OBS_ALLOW_DIRECT_RENDERING)) {
+		logger.error("Could not begin processing filter");
+		obs_source_skip_video_filter(source);
+		return;
+	}
+
+	gs_set_viewport(0, 0, width, height);
+	gs_ortho(0.0f, (float)width, 0.0f, (float)height, -100.0f, 100.0f);
+	gs_matrix_identity();
+
+	obs_source_process_filter_end(source, mainEffect.effect.get(), width, height);
+}
+
+void RenderingContext::renderSegmenterInput()
+{
+	RenderTargetGuard renderTargetGuard;
+	TransformStateGuard transformStateGuard;
+
+	gs_set_render_target_with_color_space(bgrxSegmentorInput.get(), nullptr, GS_CS_SRGB);
+
+	gs_clear(GS_CLEAR_COLOR, &blackColor, 1.0f, 0);
+
+	gs_set_viewport(maskRoiOffsetX, maskRoiOffsetY, maskRoiWidth, maskRoiHeight);
+	gs_ortho(0.0f, static_cast<float>(width), 0.0f, static_cast<float>(height), -100.0f, 100.0f);
+	gs_matrix_identity();
+
+	mainEffect.draw(width, height, bgrxOriginalImage.get());
+}
+
+void RenderingContext::videoRender()
+{
+	try {
+		readerSegmenterInput.sync();
+	} catch (const std::exception &e) {
+		logger.error("Failed to sync texture reader: {}", e.what());
+	}
+
+	renderOriginalImage();
+	renderSegmenterInput();
+
+	const std::uint8_t *segmentationMaskData =
+		selfieSegmenter.getMask().data() + (maskRoiOffsetY * SelfieSegmenter::INPUT_WIDTH + maskRoiOffsetX);
+	gs_texture_set_image(r8SegmentationMask.get(), segmentationMaskData, width, 0);
+	mainEffect.drawWithMask(width, height, bgrxOriginalImage.get(), r8SegmentationMask.get());
+
+	readerSegmenterInput.stage(bgrxSegmentorInput.get());
+}
+
+obs_source_frame *RenderingContext::filterVideo(obs_source_frame *frame)
+{
+	selfieSegmenter.process(readerSegmenterInput.getBuffer().data());
+	return frame;
 }
 
 } // namespace obs_backgroundremoval_lite

--- a/src/RenderingContext.cpp
+++ b/src/RenderingContext.cpp
@@ -156,8 +156,9 @@ void RenderingContext::videoRender()
 
 	const std::uint8_t *segmentationMaskData =
 		selfieSegmenter.getMask().data() + (maskRoiOffsetY * SelfieSegmenter::INPUT_WIDTH + maskRoiOffsetX);
-	gs_texture_set_image(r8SegmentationMask.get(), segmentationMaskData, width, 0);
-	mainEffect.drawWithMask(width, height, bgrxOriginalImage.get(), r8SegmentationMask.get());
+	gs_texture_set_image(r8SegmentationMask.get(), segmentationMaskData, SelfieSegmenter::INPUT_WIDTH, 0);
+	// mainEffect.drawWithMask(width, height, bgrxOriginalImage.get(), r8SegmentationMask.get());
+	mainEffect.draw(width, height, r8SegmentationMask.get());
 
 	readerSegmenterInput.stage(bgrxSegmenterInput.get());
 }

--- a/src/RenderingContext.hpp
+++ b/src/RenderingContext.hpp
@@ -1,0 +1,48 @@
+/*
+OBS Background Removal Lite
+Copyright (C) 2025 Kaito Udagawa umireon@kaito.tokyo
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>
+*/
+
+#pragma once
+
+#include <cstdint>
+
+#include <obs-bridge-utils/gs_unique.hpp>
+#include <obs-bridge-utils/ILogger.hpp>
+
+#include "AsyncTextureReader.hpp"
+
+namespace kaito_tokyo {
+namespace obs_backgroundremoval_lite {
+
+class RenderingContext {
+public:
+    const std::uint32_t width;
+    const std::uint32_t height;
+    const kaito_tokyo::obs_bridge_utils::ILogger &logger;
+
+	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t bgrxOriginalImage;
+	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t bgrxSegmentorInput;
+	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r8SegmentationMask;
+
+    const AsyncTextureReader readerSegmenterInput;
+
+    RenderingContext(std::uint32_t width, std::uint32_t height, const kaito_tokyo::obs_bridge_utils::ILogger &logger) noexcept;
+    ~RenderingContext() noexcept;
+};
+
+} // namespace obs_backgroundremoval_lite
+} // namespace kaito_tokyo

--- a/src/RenderingContext.hpp
+++ b/src/RenderingContext.hpp
@@ -27,8 +27,8 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include "AsyncTextureReader.hpp"
 #include "MainEffect.hpp"
-#include "TaskQueue.hpp"
 #include "SelfieSegmenter.hpp"
+#include "ThrottledTaskQueue.hpp"
 
 namespace kaito_tokyo {
 namespace obs_backgroundremoval_lite {
@@ -41,6 +41,7 @@ private:
 
 	AsyncTextureReader readerSegmenterInput;
 	SelfieSegmenter selfieSegmenter;
+	ThrottledTaskQueue &selfieSegmenterTaskQueue;
 
 public:
 	const std::uint32_t width;
@@ -61,8 +62,8 @@ private:
 
 public:
 	RenderingContext(obs_source_t *source, const kaito_tokyo::obs_bridge_utils::ILogger &logger,
-			 const MainEffect &mainEffect, const ncnn::Net &selfieSegmenterNet, std::uint32_t width,
-			 std::uint32_t height);
+			 const MainEffect &mainEffect, const ncnn::Net &selfieSegmenterNet,
+			 ThrottledTaskQueue &selfieSegmenterTaskQueue, std::uint32_t width, std::uint32_t height);
 	~RenderingContext() noexcept;
 
 	void videoTick(float seconds);

--- a/src/RenderingContext.hpp
+++ b/src/RenderingContext.hpp
@@ -24,24 +24,51 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <obs-bridge-utils/ILogger.hpp>
 
 #include "AsyncTextureReader.hpp"
+#include "MainEffect.hpp"
+#include "SelfieSegmenter.hpp"
+#include "TaskQueue.hpp"
 
 namespace kaito_tokyo {
 namespace obs_backgroundremoval_lite {
 
 class RenderingContext {
-public:
-    const std::uint32_t width;
-    const std::uint32_t height;
-    const kaito_tokyo::obs_bridge_utils::ILogger &logger;
+private:
+	obs_source_t *const source;
+	const kaito_tokyo::obs_bridge_utils::ILogger &logger;
+	const MainEffect &mainEffect;
 
+	AsyncTextureReader readerSegmenterInput;
+	SelfieSegmenter selfieSegmenter;
+
+public:
+	const std::uint32_t width;
+	const std::uint32_t height;
+
+private:
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t bgrxOriginalImage;
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t bgrxSegmentorInput;
+
+	const std::uint32_t maskRoiOffsetX;
+	const std::uint32_t maskRoiOffsetY;
+	const std::uint32_t maskRoiWidth;
+	const std::uint32_t maskRoiHeight;
+
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r8SegmentationMask;
 
-    const AsyncTextureReader readerSegmenterInput;
+	vec4 blackColor = {0.0f, 0.0f, 0.0f, 1.0f};
 
-    RenderingContext(std::uint32_t width, std::uint32_t height, const kaito_tokyo::obs_bridge_utils::ILogger &logger) noexcept;
-    ~RenderingContext() noexcept;
+public:
+	RenderingContext(obs_source_t *source, const kaito_tokyo::obs_bridge_utils::ILogger &logger,
+			 const MainEffect &mainEffect, std::uint32_t width, std::uint32_t height) noexcept;
+	~RenderingContext() noexcept;
+
+	void videoTick(float seconds);
+	void videoRender();
+	obs_source_frame *filterVideo(obs_source_frame *frame);
+
+private:
+	void renderOriginalImage();
+	void renderSegmenterInput();
 };
 
 } // namespace obs_backgroundremoval_lite

--- a/src/RenderingContext.hpp
+++ b/src/RenderingContext.hpp
@@ -20,13 +20,15 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include <cstdint>
 
+#include <net.h>
+
 #include <obs-bridge-utils/gs_unique.hpp>
 #include <obs-bridge-utils/ILogger.hpp>
 
 #include "AsyncTextureReader.hpp"
 #include "MainEffect.hpp"
-#include "SelfieSegmenter.hpp"
 #include "TaskQueue.hpp"
+#include "SelfieSegmenter.hpp"
 
 namespace kaito_tokyo {
 namespace obs_backgroundremoval_lite {
@@ -46,7 +48,7 @@ public:
 
 private:
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t bgrxOriginalImage;
-	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t bgrxSegmentorInput;
+	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t bgrxSegmenterInput;
 
 	const std::uint32_t maskRoiOffsetX;
 	const std::uint32_t maskRoiOffsetY;
@@ -59,7 +61,8 @@ private:
 
 public:
 	RenderingContext(obs_source_t *source, const kaito_tokyo::obs_bridge_utils::ILogger &logger,
-			 const MainEffect &mainEffect, std::uint32_t width, std::uint32_t height) noexcept;
+			 const MainEffect &mainEffect, const ncnn::Net &selfieSegmenterNet, std::uint32_t width,
+			 std::uint32_t height);
 	~RenderingContext() noexcept;
 
 	void videoTick(float seconds);

--- a/src/SelfieSegmenter.hpp
+++ b/src/SelfieSegmenter.hpp
@@ -37,34 +37,6 @@ namespace kaito_tokyo {
 namespace obs_backgroundremoval_lite {
 
 /**
- * @class NcnnInferenceEngine
- * @brief A class responsible for loading and running ncnn models.
- */
-class NcnnInferenceEngine {
-public:
-	NcnnInferenceEngine(const kaito_tokyo::obs_bridge_utils::unique_bfree_char_t &param_path,
-			    const kaito_tokyo::obs_bridge_utils::unique_bfree_char_t &bin_path)
-	{
-		if (net.load_param(param_path.get()) != 0) {
-			throw std::runtime_error(std::string("Failed to load ncnn param file: ") + param_path.get());
-		}
-		if (net.load_model(bin_path.get()) != 0) {
-			throw std::runtime_error(std::string("Failed to load ncnn bin file: ") + bin_path.get());
-		}
-	}
-
-	void run(const ncnn::Mat &input, ncnn::Mat &output) const
-	{
-		ncnn::Extractor ex = net.create_extractor();
-		ex.input("in0", input);
-		ex.extract("out0", output);
-	}
-
-private:
-	ncnn::Net net;
-};
-
-/**
  * @class MaskBuffer
  * @brief A thread-safe double buffer for managing mask data.
  */
@@ -115,9 +87,18 @@ public:
 	static constexpr int INPUT_HEIGHT = 256;
 	static constexpr int PIXEL_COUNT = INPUT_WIDTH * INPUT_HEIGHT;
 
-	SelfieSegmenter(const kaito_tokyo::obs_bridge_utils::unique_bfree_char_t &param_path,
-			const kaito_tokyo::obs_bridge_utils::unique_bfree_char_t &bin_path)
-		: inferenceEngine(param_path, bin_path),
+	static constexpr float MEAN_VALS[3] = {0.0f, 0.0f, 0.0f};
+	static constexpr float NORM_VALS[3] = {1.0f / 255.0f, 1.0f / 255.0f, 1.0f / 255.0f};
+
+	const ncnn::Net &selfieSegmenterNet;
+	MaskBuffer maskBuffer;
+
+	// Member variables to reuse memory for ncnn::Mat
+	ncnn::Mat m_inputMat;
+	ncnn::Mat m_outputMat;
+
+	SelfieSegmenter(const ncnn::Net &_selfieSegmenterNet)
+		: selfieSegmenterNet(_selfieSegmenterNet),
 		  maskBuffer(PIXEL_COUNT)
 	{
 		// Pre-allocate memory for the input Mat.
@@ -138,7 +119,9 @@ public:
 		preprocess(bgra_data);
 
 		// 2. Run inference using member Mats
-		inferenceEngine.run(m_inputMat, m_outputMat);
+		ncnn::Extractor ex = selfieSegmenterNet.create_extractor();
+		ex.input("in0", m_inputMat);
+		ex.extract("out0", m_outputMat);
 
 		// 3. Get a reference to the buffer to write to
 		std::vector<std::uint8_t> &maskToWrite = maskBuffer.beginWrite();
@@ -184,16 +167,6 @@ private:
 			mask[i] = static_cast<std::uint8_t>(std::max(0.f, std::min(255.f, src_ptr[i] * 255.f)));
 		}
 	}
-
-	NcnnInferenceEngine inferenceEngine;
-	MaskBuffer maskBuffer;
-
-	// Member variables to reuse memory for ncnn::Mat
-	ncnn::Mat m_inputMat;
-	ncnn::Mat m_outputMat;
-
-	static constexpr float MEAN_VALS[3] = {0.0f, 0.0f, 0.0f};
-	static constexpr float NORM_VALS[3] = {1.0f / 255.0f, 1.0f / 255.0f, 1.0f / 255.0f};
 };
 
 } // namespace obs_backgroundremoval_lite

--- a/src/SelfieSegmenter.hpp
+++ b/src/SelfieSegmenter.hpp
@@ -146,8 +146,6 @@ private:
 		float *r_channel = m_inputMat.channel(0);
 		float *g_channel = m_inputMat.channel(1);
 		float *b_channel = m_inputMat.channel(2);
-		m_inputMat.from_pixels(bgra_data, ncnn::Mat::PIXEL_BGRA2RGB, INPUT_WIDTH, INPUT_HEIGHT);
-		m_inputMat.substract_mean_normalize(MEAN_VALS, NORM_VALS);
 
 		for (int i = 0; i < PIXEL_COUNT; i++) {
 			// BGRA layout and normalization formula: (pixel - mean) * norm


### PR DESCRIPTION
This pull request refactors the rendering and segmentation logic for the OBS Background Removal Lite plugin by introducing a new `RenderingContext` class. The changes move most of the video processing, resource management, and segmentation workflow out of `MainPluginContext` and into this new class, resulting in a cleaner and more modular codebase. The update also improves resource management, error handling, and code organization.

Key changes include:

**Rendering and Segmentation Refactor:**

* Introduced a new `RenderingContext` class (`src/RenderingContext.cpp`, `src/RenderingContext.hpp`) that encapsulates all rendering, segmentation, and related resource management, replacing the previous manual handling in `MainPluginContext`. (`[[1]](diffhunk://#diff-e141b8656df0ee831c8c03f2ab6b1cc3ec7f1c87776f9914b30227c0aed2a9b2R1-R185)`, `[[2]](diffhunk://#diff-95f698c2cdb5b41cd4071c9b0b0bfce87a4e459f054ce8669fbbe5b34c35e8b2R1-R79)`)
* Updated `MainPluginContext` to delegate video processing (`videoTick`, `videoRender`, and `filterVideo`) to the `RenderingContext` instance, and removed obsolete member variables and methods related to manual texture and task management. (`[[1]](diffhunk://#diff-2d840159c3cd8f3bbc7cd26789596da8edde2415b7376f8de3d92403e91be39bL131-R157)`, `[[2]](diffhunk://#diff-2d840159c3cd8f3bbc7cd26789596da8edde2415b7376f8de3d92403e91be39bL76-R81)`, `[[3]](diffhunk://#diff-dd6f478e1ff846c44f174b36817a5bcddcc19c6eb10f58501e6d8f144e74c4b7L77-L104)`)

**Codebase Cleanup and Simplification:**

* Removed the `RenderingGuard` struct and related manual graphics state management from `MainEffect.hpp`, as this is now handled by guards in `RenderingContext`. (`[src/MainEffect.hppL34-L57](diffhunk://#diff-ea152ee3ce682ff357aa697a7be8025c477f2845fa2361d7dbe4e7315f737ca2L34-L57)`)
* Changed method signatures in `MainEffect` to mark `draw` and `drawWithMask` as `const`, reflecting their stateless nature. (`[[1]](diffhunk://#diff-ea152ee3ce682ff357aa697a7be8025c477f2845fa2361d7dbe4e7315f737ca2L111-R87)`, `[[2]](diffhunk://#diff-ea152ee3ce682ff357aa697a7be8025c477f2845fa2361d7dbe4e7315f737ca2L127-R103)`)
* Updated `CMakeLists.txt` to add `src/RenderingContext.cpp` to the build sources. (`[CMakeLists.txtL50-R50](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL50-R50)`)

**Resource and Error Management Improvements:**

* Improved initialization and error handling for the segmentation model in `MainPluginContext`, ensuring that required files are present and loaded correctly. (`[src/MainPluginContext.cppL28-R55](diffhunk://#diff-2d840159c3cd8f3bbc7cd26789596da8edde2415b7376f8de3d92403e91be39bL28-R55)`)
* Simplified and clarified the logic for handling video frame size changes and rendering context recreation. (`[src/MainPluginContext.cppL131-R157](diffhunk://#diff-2d840159c3cd8f3bbc7cd26789596da8edde2415b7376f8de3d92403e91be39bL131-R157)`)

**Header and Dependency Updates:**

* Updated includes in `MainPluginContext.h` to use the new `RenderingContext` and `ThrottledTaskQueue`, and removed unused or redundant includes. (`[src/MainPluginContext.hL40-R66](diffhunk://#diff-dd6f478e1ff846c44f174b36817a5bcddcc19c6eb10f58501e6d8f144e74c4b7L40-R66)`)

These changes collectively improve maintainability, modularity, and robustness of the plugin's rendering and segmentation pipeline.

**References:**  
[[1]](diffhunk://#diff-e141b8656df0ee831c8c03f2ab6b1cc3ec7f1c87776f9914b30227c0aed2a9b2R1-R185) [[2]](diffhunk://#diff-95f698c2cdb5b41cd4071c9b0b0bfce87a4e459f054ce8669fbbe5b34c35e8b2R1-R79) [[3]](diffhunk://#diff-2d840159c3cd8f3bbc7cd26789596da8edde2415b7376f8de3d92403e91be39bL131-R157) [[4]](diffhunk://#diff-2d840159c3cd8f3bbc7cd26789596da8edde2415b7376f8de3d92403e91be39bL76-R81) [[5]](diffhunk://#diff-dd6f478e1ff846c44f174b36817a5bcddcc19c6eb10f58501e6d8f144e74c4b7L77-L104) [[6]](diffhunk://#diff-ea152ee3ce682ff357aa697a7be8025c477f2845fa2361d7dbe4e7315f737ca2L34-L57) [[7]](diffhunk://#diff-ea152ee3ce682ff357aa697a7be8025c477f2845fa2361d7dbe4e7315f737ca2L111-R87) [[8]](diffhunk://#diff-ea152ee3ce682ff357aa697a7be8025c477f2845fa2361d7dbe4e7315f737ca2L127-R103) [[9]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL50-R50) [[10]](diffhunk://#diff-2d840159c3cd8f3bbc7cd26789596da8edde2415b7376f8de3d92403e91be39bL28-R55) [[11]](diffhunk://#diff-dd6f478e1ff846c44f174b36817a5bcddcc19c6eb10f58501e6d8f144e74c4b7L40-R66)