### PR TITLE
Update main.effect

### DIFF
--- a/data/effects/main.effect
+++ b/data/effects/main.effect
@@ -27,24 +27,13 @@ float4 PSDraw(VertInOut vert_in) : TARGET
 	return image.Sample(def_sampler, vert_in.uv);
 }
 
-float random(float2 p)
-{
-	float3 p3 = frac(p.xyx * float3(443.897, 441.423, 437.195));
-	p3 += dot(p3, p3.yzx + 19.19);
-	return frac((p3.x + p3.y) * p3.z);
-}
-
 float4 PSDrawWithMask(VertInOut vert_in) : TARGET
 {
 	float2 uv = vert_in.uv;
 	float4 final_color;
 
 	final_color.rgb = image.Sample(def_sampler, uv).rgb;
-
-	float mask_alpha = mask.Sample(def_sampler, uv).r;
-	float threshold = random(uv);
-
-	final_color.a = step(threshold, mask_alpha);
+	final_color.a = mask.Sample(def_sampler, uv).r;
 
 	return final_color;
 }


### PR DESCRIPTION
This pull request simplifies the alpha masking logic in the `PSDrawWithMask` function by removing the use of a random threshold and directly assigning the mask's sampled value to the alpha channel.

Masking logic simplification:

* Removed the `random` function and the stochastic thresholding logic from `PSDrawWithMask`, now setting `final_color.a` directly to the mask's sampled red channel value. (`data/effects/main.effect`)