### PR TITLE
Move gs_unique::drain() call to MainPluginContext.cpp

### DIFF
--- a/src/MainPluginContext.cpp
+++ b/src/MainPluginContext.cpp
@@ -174,6 +174,7 @@ try {
 		renderingContext = std::make_shared<RenderingContext>(
 			source, logger, mainEffect, selfieSegmenterNet, selfieSegmenterTaskQueue, frame->width,
 			frame->height, preset.filterLevel, preset.gfRadius, preset.gfEps, preset.gfSubsamplingRate);
+		gs_unique::drain();
 	}
 
 	return frame;

--- a/src/MainPluginContext_c.cpp
+++ b/src/MainPluginContext_c.cpp
@@ -231,7 +231,6 @@ try {
 
 	auto self = static_cast<std::shared_ptr<MainPluginContext> *>(data);
 	obs_source_frame *result = self->get()->filterVideo(frame);
-	gs_unique::drain();
 	return result;
 } catch (const std::exception &e) {
 	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to filter video in main plugin context: %s", e.what());


### PR DESCRIPTION
This pull request makes a minor adjustment to the graphics resource management in the video filtering workflow. The main change is moving the call to `gs_unique::drain()` from the C wrapper function to the C++ context, ensuring resources are drained immediately after creating the rendering context.

Resource management update:

* Moved the call to `gs_unique::drain()` from `src/MainPluginContext_c.cpp` to immediately after the creation of the `RenderingContext` in `src/MainPluginContext.cpp`, ensuring timely draining of graphics resources. [[1]](diffhunk://#diff-2d840159c3cd8f3bbc7cd26789596da8edde2415b7376f8de3d92403e91be39bR177) [[2]](diffhunk://#diff-674e7bbaba12bf57fba3c0cae581252744c9b2c0c5a38cbd8a739b2d32673b82L234)Relocates the gs_unique::drain() call from MainPluginContext_c.cpp to MainPluginContext.cpp after creating the RenderingContext. This ensures resource draining occurs at the appropriate stage in the video filtering process.