### PR TITLE
Update Package-Windows.ps1

### DIFF
--- a/.github/scripts/Package-Windows.ps1
+++ b/.github/scripts/Package-Windows.ps1
@@ -38,7 +38,7 @@ function Package {
 
     $UtilityFunctions = Get-ChildItem -Path $PSScriptRoot/utils.pwsh/*.ps1 -Recurse
 
-    foreach( $Utility in $UtilityFunctions ) {
+    foreach ( $Utility in $UtilityFunctions ) {
         Write-Debug "Loading $($Utility.FullName)"
         . $Utility.FullName
     }
@@ -51,7 +51,7 @@ function Package {
 
     $RemoveArgs = @{
         ErrorAction = 'SilentlyContinue'
-        Path = @(
+        Path        = @(
             "${ProjectRoot}/release/${ProductName}-*-windows-*.zip"
         )
     }
@@ -59,13 +59,35 @@ function Package {
     Remove-Item @RemoveArgs
 
     Log-Group "Archiving ${ProductName}..."
+
+    $SourceDir = "${ProjectRoot}/release/${Configuration}"
+    $StagingDir = "${ProjectRoot}/release/staging-${Target}"
+
+    if ( Test-Path -Path $StagingDir ) {
+        Remove-Item -Path $StagingDir -Recurse -Force
+    }
+    New-Item -Path $StagingDir -ItemType Directory | Out-Null
+
+    # Create OBS plugin structure
+    $ObsPluginDir = New-Item -Path "$StagingDir/obs-plugins/64bit" -ItemType Directory -Force
+    $DataPluginDir = New-Item -Path "$StagingDir/data/obs-plugins/$ProductName" -ItemType Directory -Force
+
+    # Copy plugin binaries
+    Copy-Item -Path "$SourceDir/obs-plugins/64bit/*" -Destination $ObsPluginDir -Recurse
+
+    # Copy data files
+    Copy-Item -Path "$SourceDir/data/obs-plugins/*" -Destination $DataPluginDir -Recurse
+
     $CompressArgs = @{
-        Path = (Get-ChildItem -Path "${ProjectRoot}/release/${Configuration}" -Exclude "${OutputName}*.*")
+        Path            = (Get-ChildItem -Path $StagingDir).FullName
         CompressionLevel = 'Optimal'
         DestinationPath = "${ProjectRoot}/release/${OutputName}.zip"
-        Verbose = ($Env:CI -ne $null)
+        Verbose         = ($Env:CI -ne $null)
     }
     Compress-Archive -Force @CompressArgs
+
+    Remove-Item -Path $StagingDir -Recurse -Force
+
     Log-Group
 }
 


### PR DESCRIPTION
This pull request updates the Windows packaging script to improve the structure and contents of the release archives. The main change is the introduction of a staging directory to organize files before creating the zip archive, ensuring the correct OBS plugin structure and data files are included.

Packaging improvements:

* Added creation of a `$StagingDir` to assemble files in the correct OBS plugin structure before archiving, including subdirectories for plugin binaries and data files.
* Updated the script to copy plugin binaries and data files from the build output to the appropriate locations within the staging directory.
* Changed the archive creation step to zip the contents of the staging directory rather than the raw build output, ensuring only the intended files are included.
* Cleaned up by removing the staging directory after the archive is created.