### PR TITLE
Fix windows structure

### DIFF
--- a/.github/scripts/Package-Windows.ps1
+++ b/.github/scripts/Package-Windows.ps1
@@ -68,15 +68,27 @@ function Package {
     }
     New-Item -Path $StagingDir -ItemType Directory | Out-Null
 
+    # Define source paths
+    $SourcePluginPath = "$SourceDir/obs-plugins/64bit/$ProductName"
+    $SourceDataPath = "$SourceDir/data/obs-plugins"
+
+    # Check if source paths exist
+    if ( ! (Test-Path -Path $SourcePluginPath) ) {
+        throw "Cannot find plugin source directory: $SourcePluginPath"
+    }
+    if ( ! (Test-Path -Path $SourceDataPath) ) {
+        throw "Cannot find data source directory: $SourceDataPath"
+    }
+
     # Create OBS plugin structure
     $ObsPluginDir = New-Item -Path "$StagingDir/obs-plugins/64bit" -ItemType Directory -Force
     $DataPluginDir = New-Item -Path "$StagingDir/data/obs-plugins/$ProductName" -ItemType Directory -Force
 
     # Copy plugin binaries
-    Copy-Item -Path "$SourceDir/obs-plugins/64bit/*" -Destination $ObsPluginDir -Recurse
+    Copy-Item -Path "$SourcePluginPath/*" -Destination $ObsPluginDir -Recurse
 
     # Copy data files
-    Copy-Item -Path "$SourceDir/data/obs-plugins/*" -Destination $DataPluginDir -Recurse
+    Copy-Item -Path "$SourceDataPath/*" -Destination $DataPluginDir -Recurse
 
     $CompressArgs = @{
         Path            = (Get-ChildItem -Path $StagingDir).FullName

--- a/.github/scripts/Package-Windows.ps1
+++ b/.github/scripts/Package-Windows.ps1
@@ -38,7 +38,7 @@ function Package {
 
     $UtilityFunctions = Get-ChildItem -Path $PSScriptRoot/utils.pwsh/*.ps1 -Recurse
 
-    foreach( $Utility in $UtilityFunctions ) {
+    foreach ( $Utility in $UtilityFunctions ) {
         Write-Debug "Loading $($Utility.FullName)"
         . $Utility.FullName
     }
@@ -51,7 +51,7 @@ function Package {
 
     $RemoveArgs = @{
         ErrorAction = 'SilentlyContinue'
-        Path = @(
+        Path        = @(
             "${ProjectRoot}/release/${ProductName}-*-windows-*.zip"
         )
     }
@@ -59,13 +59,35 @@ function Package {
     Remove-Item @RemoveArgs
 
     Log-Group "Archiving ${ProductName}..."
+
+    $SourceDir = "${ProjectRoot}/release/${Configuration}"
+    $StagingDir = "${ProjectRoot}/release/staging-${Target}"
+
+    if ( Test-Path -Path $StagingDir ) {
+        Remove-Item -Path $StagingDir -Recurse -Force
+    }
+    New-Item -Path $StagingDir -ItemType Directory | Out-Null
+
+    # Create OBS plugin structure
+    $ObsPluginDir = New-Item -Path "$StagingDir/obs-plugins/64bit" -ItemType Directory -Force
+    $DataPluginDir = New-Item -Path "$StagingDir/data/obs-plugins/$ProductName" -ItemType Directory -Force
+
+    # Copy plugin binaries
+    Copy-Item -Path "$SourceDir/obs-plugins/64bit/*" -Destination $ObsPluginDir -Recurse
+
+    # Copy data files
+    Copy-Item -Path "$SourceDir/data/obs-plugins/*" -Destination $DataPluginDir -Recurse
+
     $CompressArgs = @{
-        Path = (Get-ChildItem -Path "${ProjectRoot}/release/${Configuration}" -Exclude "${OutputName}*.*")
+        Path            = (Get-ChildItem -Path $StagingDir).FullName
         CompressionLevel = 'Optimal'
         DestinationPath = "${ProjectRoot}/release/${OutputName}.zip"
-        Verbose = ($Env:CI -ne $null)
+        Verbose         = ($Env:CI -ne $null)
     }
     Compress-Archive -Force @CompressArgs
+
+    Remove-Item -Path $StagingDir -Recurse -Force
+
     Log-Group
 }
 


### PR DESCRIPTION
This pull request updates the Windows packaging script to improve how plugin binaries and data files are staged and archived. The main change is the introduction of a dedicated staging directory to ensure that only the necessary files are included in the final archive, and to better mirror the expected OBS plugin directory structure.

Packaging process improvements:

* [`.github/scripts/Package-Windows.ps1`](diffhunk://#diff-70923ebecc8cb74b972ffab76ff9428a1ab5fc878373a4be57c49a0687621aa7R62-R102): Added logic to create a staging directory, verify the existence of plugin and data source directories, and copy the relevant files into the correct subdirectories within the staging area. The script now archives the contents of the staging directory instead of the entire build output, and cleans up the staging directory afterward.