### PR TITLE
Update Package-Windows.ps1

### DIFF
--- a/.github/scripts/Package-Windows.ps1
+++ b/.github/scripts/Package-Windows.ps1
@@ -60,8 +60,7 @@ function Package {
 
     Log-Group "Archiving ${ProductName}..."
 
-    $SourceDir = "${ProjectRoot}/release/${Configuration}"
-    Get-ChildItem -Recurse -Path $SourceDir
+    $SourceDir = "${ProjectRoot}/release/${Configuration}/${ProductName}"
     $StagingDir = "${ProjectRoot}/release/staging-${Target}"
 
     if ( Test-Path -Path $StagingDir ) {

--- a/.github/scripts/Package-Windows.ps1
+++ b/.github/scripts/Package-Windows.ps1
@@ -73,10 +73,10 @@ function Package {
     $DataPluginDir = New-Item -Path "$StagingDir/data/obs-plugins/$ProductName" -ItemType Directory -Force
 
     # Copy plugin binaries
-    Copy-Item -Path "$SourceDir/obs-plugins/64bit/*" -Destination $ObsPluginDir -Recurse
+    Copy-Item -Path "$SourceDir/bin/64bit/*" -Destination $ObsPluginDir -Recurse
 
     # Copy data files
-    Copy-Item -Path "$SourceDir/data/obs-plugins/*" -Destination $DataPluginDir -Recurse
+    Copy-Item -Path "$SourceDir/data/*" -Destination $DataPluginDir -Recurse
 
     $CompressArgs = @{
         Path            = (Get-ChildItem -Path $StagingDir).FullName

--- a/.github/scripts/Package-Windows.ps1
+++ b/.github/scripts/Package-Windows.ps1
@@ -61,6 +61,7 @@ function Package {
     Log-Group "Archiving ${ProductName}..."
 
     $SourceDir = "${ProjectRoot}/release/${Configuration}"
+    Get-ChildItem -Recurse -Path $SourceDir
     $StagingDir = "${ProjectRoot}/release/staging-${Target}"
 
     if ( Test-Path -Path $StagingDir ) {


### PR DESCRIPTION
This pull request updates the packaging script for Windows to fix the paths used when copying plugin binaries and data files. The changes ensure that the correct files are included in the package by adjusting the source directories.

Packaging script improvements:

* Changed the source path for plugin binaries from `obs-plugins/64bit/*` to `bin/64bit/*` to correctly reference the built binaries. (.github/scripts/Package-Windows.ps1)
* Updated the source path for data files from `data/obs-plugins/*` to `data/*` to ensure all relevant data files are copied. (.github/scripts/Package-Windows.ps1)