### PR TITLE
Merge passes

### DIFF
--- a/data/effects/main.effect
+++ b/data/effects/main.effect
@@ -127,18 +127,19 @@ float4 PSHorizontalBoxFilterR8KS17(VertInOut vert_in) : TARGET
 }
 
 /**
- * @brief Applies an optimized 1D horizontal box filter with a fixed kernel size of 17.
+ * @brief Combines per-element multiplication and a 1D horizontal box filter (KS=17).
  * (Pass 1 of a separable filter)
+ * @note This shader combines the operations of PSMultiplyR8 and PSHorizontalBoxFilterR8KS17.
  */
 float4 PSHorizontalBoxFilterWithMulR8KS17(VertInOut vert_in) : TARGET
 {
 	float2 uv = vert_in.uv;
 
-    float sum = image.Sample(linear_sampler, uv).r * image1.Sample(linear_sampler, uv).r;
+    float sum = image.Sample(point_sampler, uv).r * image1.Sample(point_sampler, uv).r;
     for (int i = 1; i <= 8; i++) {
         float2 offset = float2(i * texelWidth, 0.0f);
-        sum += image.Sample(point_sampler, uv + offset).r * image1.Sample(linear_sampler, uv + offset).r;
-        sum += image.Sample(point_sampler, uv - offset).r * image1.Sample(linear_sampler, uv - offset).r;
+        sum += image.Sample(point_sampler, uv + offset).r * image1.Sample(point_sampler, uv + offset).r;
+        sum += image.Sample(point_sampler, uv - offset).r * image1.Sample(point_sampler, uv - offset).r;
     }
 
 	float luma = sum / 17.0f;
@@ -152,14 +153,15 @@ float square(float x) {
 }
 
 /**
- * @brief Applies an optimized 1D horizontal box filter with a fixed kernel size of 17.
+ * @brief Combines squaring and a 1D horizontal box filter (KS=17).
  * (Pass 1 of a separable filter)
+ * @note This shader combines the operations of PSSquareR8 and PSHorizontalBoxFilterR8KS17.
  */
 float4 PSHorizontalBoxFilterWithSqR8KS17(VertInOut vert_in) : TARGET
 {
 	float2 uv = vert_in.uv;
 
-    float sum = square(image.Sample(linear_sampler, uv).r);
+    float sum = square(image.Sample(point_sampler, uv).r);
     for (int i = 1; i <= 8; i++) {
         float2 offset = float2(i * texelWidth, 0.0f);
         sum += square(image.Sample(point_sampler, uv + offset).r);
@@ -190,28 +192,6 @@ float4 PSVerticalBoxFilterR8KS17(VertInOut vert_in) : TARGET
 	float luma = (image.Sample(linear_sampler, uv).r + bilinear_sum * 2.0f) / 17.0f;
 
 	return float4(luma, luma, luma, 1.0f);
-}
-
-/**
- * @brief Performs per-element multiplication of the R channels of 'image' and 'image1'.
- * @note 'image' and 'image1' must be the same size.
- */
-float4 PSMultiplyR8(VertInOut vert_in) : TARGET
-{
-	float2 uv = vert_in.uv;
-	float value = image.Sample(point_sampler, uv).r * image1.Sample(point_sampler, uv).r;
-	return float4(value, value, value, 1.0f);
-}
-
-/**
- * @brief Calculates the square of the R channel of the 'image' texture.
- */
-float4 PSSquareR8(VertInOut vert_in) : TARGET
-{
-	float2 uv = vert_in.uv;
-	float r = image.Sample(point_sampler, uv).r;
-	float value = r * r;
-	return float4(value, value, value, 1.0f);
 }
 
 /**
@@ -334,30 +314,30 @@ technique HorizontalBoxFilterR8KS17
 	}
 }
 
+technique HorizontalBoxFilterWithMulR8KS17
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader = PSHorizontalBoxFilterWithMulR8KS17(vert_in);
+	}
+}
+
+technique HorizontalBoxFilterWithSqR8KS17
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader = PSHorizontalBoxFilterWithSqR8KS17(vert_in);
+	}
+}
+
 technique VerticalBoxFilterR8KS17
 {
 	pass
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader = PSVerticalBoxFilterR8KS17(vert_in);
-	}
-}
-
-technique MultiplyR8
-{
-	pass
-	{
-		vertex_shader = VSDefault(vert_in);
-		pixel_shader = PSMultiplyR8(vert_in);
-	}
-}
-
-technique SquareR8
-{
-	pass
-	{
-		vertex_shader = VSDefault(vert_in);
-		pixel_shader = PSSquareR8(vert_in);
 	}
 }
 

--- a/data/effects/main.effect
+++ b/data/effects/main.effect
@@ -127,6 +127,51 @@ float4 PSHorizontalBoxFilterR8KS17(VertInOut vert_in) : TARGET
 }
 
 /**
+ * @brief Applies an optimized 1D horizontal box filter with a fixed kernel size of 17.
+ * (Pass 1 of a separable filter)
+ */
+float4 PSHorizontalBoxFilterWithMulR8KS17(VertInOut vert_in) : TARGET
+{
+	float2 uv = vert_in.uv;
+
+    float sum = image.Sample(linear_sampler, uv).r * image1.Sample(linear_sampler, uv).r;
+    for (int i = 1; i <= 8; i++) {
+        float2 offset = float2(i * texelWidth, 0.0f);
+        sum += image.Sample(point_sampler, uv + offset).r * image1.Sample(linear_sampler, uv + offset).r;
+        sum += image.Sample(point_sampler, uv - offset).r * image1.Sample(linear_sampler, uv - offset).r;
+    }
+
+	float luma = sum / 17.0f;
+
+	return float4(luma, luma, luma, 1.0f);
+}
+
+
+float square(float x) {
+    return x * x;
+}
+
+/**
+ * @brief Applies an optimized 1D horizontal box filter with a fixed kernel size of 17.
+ * (Pass 1 of a separable filter)
+ */
+float4 PSHorizontalBoxFilterWithSqR8KS17(VertInOut vert_in) : TARGET
+{
+	float2 uv = vert_in.uv;
+
+    float sum = square(image.Sample(linear_sampler, uv).r);
+    for (int i = 1; i <= 8; i++) {
+        float2 offset = float2(i * texelWidth, 0.0f);
+        sum += square(image.Sample(point_sampler, uv + offset).r);
+        sum += square(image.Sample(point_sampler, uv - offset).r);
+    }
+
+	float luma = sum / 17.0f;
+
+	return float4(luma, luma, luma, 1.0f);
+}
+
+/**
  * @brief Applies an optimized 1D vertical box filter with a fixed kernel size of 17.
  * (Pass 2 of a separable filter)
  */

--- a/src/DebugWindow.cpp
+++ b/src/DebugWindow.cpp
@@ -39,8 +39,6 @@ constexpr char textureR8GFGuideSub[] = "r8GFGuideSub";
 constexpr char textureR8GFSourceSub[] = "r8GFSourceSub";
 constexpr char textureR16fGFMeanGuideSub[] = "r16fGFMeanGuideSub";
 constexpr char textureR16fGFMeanSourceSub[] = "r16fGFMeanSourceSub";
-constexpr char textureR16fGFGuideSourceSub[] = "r16fGFGuideSourceSub";
-constexpr char textureR16fGFGuideSqSub[] = "r16fGFGuideSqSub";
 constexpr char textureR16fGFMeanGuideSourceSub[] = "r16fGFMeanGuideSourceSub";
 constexpr char textureR16fGFMeanGuideSqSub[] = "r16fGFMeanGuideSqSub";
 constexpr char textureR16fGFASub[] = "r16fGFASub";
@@ -107,8 +105,6 @@ DebugWindow::DebugWindow(std::weak_ptr<MainPluginContext> _weakMainPluginContext
 	previewTextureSelector->addItem(textureR8GFSourceSub);
 	previewTextureSelector->addItem(textureR16fGFMeanGuideSub);
 	previewTextureSelector->addItem(textureR16fGFMeanSourceSub);
-	previewTextureSelector->addItem(textureR16fGFGuideSourceSub);
-	previewTextureSelector->addItem(textureR16fGFGuideSqSub);
 	previewTextureSelector->addItem(textureR16fGFMeanGuideSourceSub);
 	previewTextureSelector->addItem(textureR16fGFMeanGuideSqSub);
 	previewTextureSelector->addItem(textureR16fGFASub);
@@ -223,18 +219,6 @@ void DebugWindow::videoRender()
 				readerR16fSub->sync();
 				readerR16fSub->stage(renderingContext->r16fGFMeanSourceSub.get());
 			}
-		} else if (currentTexture == textureR16fGFGuideSourceSub) {
-			if (readerR16fSub && readerR16fSub->width == renderingContext->gfWidthSub &&
-			    readerR16fSub->height == renderingContext->gfHeightSub) {
-				readerR16fSub->sync();
-				readerR16fSub->stage(renderingContext->r16fGFGuideSourceSub.get());
-			}
-		} else if (currentTexture == textureR16fGFGuideSqSub) {
-			if (readerR16fSub && readerR16fSub->width == renderingContext->gfWidthSub &&
-			    readerR16fSub->height == renderingContext->gfHeightSub) {
-				readerR16fSub->sync();
-				readerR16fSub->stage(renderingContext->r16fGFGuideSqSub.get());
-			}
 		} else if (currentTexture == textureR16fGFMeanGuideSourceSub) {
 			if (readerR16fSub && readerR16fSub->width == renderingContext->gfWidthSub &&
 			    readerR16fSub->height == renderingContext->gfHeightSub) {
@@ -279,14 +263,9 @@ void DebugWindow::updatePreview()
 	const std::vector<std::string> bgrx256Textures = {textureBgrxSegmenterInput};
 	const std::vector<std::string> r8MaskRoiTextures = {textureR8SegmentationMask};
 	const std::vector<std::string> subR8Textures = {textureR8GFGuideSub, textureR8GFSourceSub};
-	const std::vector<std::string> r16fTextures = {textureR16fGFMeanGuideSub,
-						       textureR16fGFMeanSourceSub,
-						       textureR16fGFGuideSourceSub,
-						       textureR16fGFGuideSqSub,
-						       textureR16fGFMeanGuideSourceSub,
-						       textureR16fGFMeanGuideSqSub,
-						       textureR16fGFASub,
-						       textureR16fGFBSub};
+	const std::vector<std::string> r16fTextures = {
+		textureR16fGFMeanGuideSub,   textureR16fGFMeanSourceSub, textureR16fGFMeanGuideSourceSub,
+		textureR16fGFMeanGuideSqSub, textureR16fGFASub,          textureR16fGFBSub};
 
 	QImage image;
 	if (std::find(bgrxTextures.begin(), bgrxTextures.end(), currentTextureStd) != bgrxTextures.end()) {

--- a/src/DebugWindow.hpp
+++ b/src/DebugWindow.hpp
@@ -60,11 +60,13 @@ private:
 
 	std::unique_ptr<AsyncTextureReader> readerBgrx;
 	std::unique_ptr<AsyncTextureReader> readerR8;
+	std::unique_ptr<AsyncTextureReader> readerR16f;
 	std::unique_ptr<AsyncTextureReader> reader256Bgrx;
 	std::unique_ptr<AsyncTextureReader> readerMaskRoiR8;
 	std::unique_ptr<AsyncTextureReader> readerSubR8;
 	std::unique_ptr<AsyncTextureReader> readerR16fSub;
 
+	std::vector<std::uint8_t> bufferR8;
 	std::vector<std::uint8_t> bufferSubR8;
 };
 

--- a/src/RenderingContext.cpp
+++ b/src/RenderingContext.cpp
@@ -78,8 +78,6 @@ RenderingContext::RenderingContext(obs_source_t *_source, const ILogger &_logger
 	  r8GFSourceSub(make_unique_gs_texture(gfWidthSub, gfHeightSub, GS_R8, 1, NULL, GS_RENDER_TARGET)),
 	  r16fGFMeanGuideSub(make_unique_gs_texture(gfWidthSub, gfHeightSub, GS_R16F, 1, NULL, GS_RENDER_TARGET)),
 	  r16fGFMeanSourceSub(make_unique_gs_texture(gfWidthSub, gfHeightSub, GS_R16F, 1, NULL, GS_RENDER_TARGET)),
-	  r16fGFGuideSourceSub(make_unique_gs_texture(gfWidthSub, gfHeightSub, GS_R16F, 1, NULL, GS_RENDER_TARGET)),
-	  r16fGFGuideSqSub(make_unique_gs_texture(gfWidthSub, gfHeightSub, GS_R16F, 1, NULL, GS_RENDER_TARGET)),
 	  r16fGFMeanGuideSourceSub(make_unique_gs_texture(gfWidthSub, gfHeightSub, GS_R16F, 1, NULL, GS_RENDER_TARGET)),
 	  r16fGFMeanGuideSqSub(make_unique_gs_texture(gfWidthSub, gfHeightSub, GS_R16F, 1, NULL, GS_RENDER_TARGET)),
 	  r16fGFASub(make_unique_gs_texture(gfWidthSub, gfHeightSub, GS_R16F, 1, NULL, GS_RENDER_TARGET)),
@@ -157,14 +155,10 @@ void RenderingContext::renderGuidedFilter(gs_texture_t *r8OriginalGrayscale, gs_
 	mainEffect.applyBoxFilterR8KS17(gfWidthSub, gfHeightSub, r16fGFMeanSourceSub.get(), r8GFSourceSub.get(),
 					r16fGFTemporary1Sub.get());
 
-	mainEffect.multiplyR8(gfWidthSub, gfHeightSub, r16fGFGuideSourceSub.get(), r8GFGuideSub.get(),
-			      r8GFSourceSub.get());
-	mainEffect.squareR8(gfWidthSub, gfHeightSub, r16fGFGuideSqSub.get(), r8GFGuideSub.get());
-
-	mainEffect.applyBoxFilterR8KS17(gfWidthSub, gfHeightSub, r16fGFMeanGuideSourceSub.get(),
-					r16fGFGuideSourceSub.get(), r16fGFTemporary1Sub.get());
-	mainEffect.applyBoxFilterR8KS17(gfWidthSub, gfHeightSub, r16fGFMeanGuideSqSub.get(), r16fGFGuideSqSub.get(),
-					r16fGFTemporary1Sub.get());
+	mainEffect.applyBoxFilterWithMulR8KS17(gfWidthSub, gfHeightSub, r16fGFMeanGuideSourceSub.get(),
+					       r8GFGuideSub.get(), r8GFSourceSub.get(), r16fGFTemporary1Sub.get());
+	mainEffect.applyBoxFilterWithSqR8KS17(gfWidthSub, gfHeightSub, r16fGFMeanGuideSqSub.get(), r8GFGuideSub.get(),
+					      r16fGFTemporary1Sub.get());
 
 	mainEffect.calculateGuidedFilterAAndB(gfWidthSub, gfHeightSub, r16fGFASub.get(), r16fGFBSub.get(),
 					      r16fGFMeanGuideSqSub.get(), r16fGFMeanGuideSub.get(),

--- a/src/RenderingContext.hpp
+++ b/src/RenderingContext.hpp
@@ -75,8 +75,6 @@ public:
 	kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r8GFSourceSub;
 	kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r16fGFMeanGuideSub;
 	kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r16fGFMeanSourceSub;
-	kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r16fGFGuideSourceSub;
-	kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r16fGFGuideSqSub;
 	kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r16fGFMeanGuideSourceSub;
 	kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r16fGFMeanGuideSqSub;
 	kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r16fGFASub;

--- a/src/RenderingContext.hpp
+++ b/src/RenderingContext.hpp
@@ -51,7 +51,7 @@ public:
 
 public:
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t bgrxOriginalImage;
-	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r8OriginalGrayscale;
+	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r16fOriginalGrayscale;
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t bgrxSegmenterInput;
 
 private:
@@ -102,7 +102,7 @@ private:
 	void renderOriginalGrayscale(gs_texture_t *bgrxOriginalImage);
 	void renderSegmenterInput(gs_texture_t *bgrxOriginalImage);
 	void renderSegmentationMask();
-	void renderGuidedFilter(gs_texture_t *r8OriginalGrayscale, gs_texture_t *r8SegmentationMask);
+	void renderGuidedFilter(gs_texture_t *r16fOriginalGrayscale, gs_texture_t *r8SegmentationMask);
 	void kickSegmentationTask();
 };
 


### PR DESCRIPTION
This pull request refactors and optimizes the implementation of box filtering and related operations in both the shader code and the C++ rendering pipeline. It introduces new combined horizontal box filter shaders that incorporate per-element multiplication and squaring, updates the techniques and code to use these new shaders, and simplifies texture management by removing unused intermediate textures and associated code. Additionally, it improves the handling and display of 16-bit float grayscale textures in the debug window.

**Shader and Filtering Pipeline Refactor:**

* Introduced new shaders `PSHorizontalBoxFilterWithMulR8KS17` and `PSHorizontalBoxFilterWithSqR8KS17` that combine per-element multiplication/squaring with a horizontal box filter, replacing the previous multi-pass approach. Updated the corresponding techniques in `main.effect` to use these new shaders and renamed them accordingly. [[1]](diffhunk://#diff-0b18719285445723753d3b029041900a3f6c64c9aba22c47c82f152aec10127aL130-R194) [[2]](diffhunk://#diff-0b18719285445723753d3b029041900a3f6c64c9aba22c47c82f152aec10127aL292-R340)
* Updated the `MainEffect` C++ class to use the new combined box filter shaders in `applyBoxFilterWithMulR8KS17` and `applyBoxFilterWithSqR8KS17` methods, replacing the previous separate multiply/square and box filter passes. Removed old multiply and square techniques and related code. [[1]](diffhunk://#diff-ea152ee3ce682ff357aa697a7be8025c477f2845fa2361d7dbe4e7315f737ca2R115-R116) [[2]](diffhunk://#diff-ea152ee3ce682ff357aa697a7be8025c477f2845fa2361d7dbe4e7315f737ca2R140-L141) [[3]](diffhunk://#diff-ea152ee3ce682ff357aa697a7be8025c477f2845fa2361d7dbe4e7315f737ca2L278-R284) [[4]](diffhunk://#diff-ea152ee3ce682ff357aa697a7be8025c477f2845fa2361d7dbe4e7315f737ca2L288-R327) [[5]](diffhunk://#diff-ea152ee3ce682ff357aa697a7be8025c477f2845fa2361d7dbe4e7315f737ca2L313-R365)

**Texture and Resource Management:**

* Removed unused intermediate textures for guide-source and guide-square products (`r16fGFGuideSourceSub`, `r16fGFGuideSqSub`) from both the rendering context and debug window code, simplifying texture management and preview logic. [[1]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L35-R61) [[2]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L103-L111) [[3]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L226-L237) [[4]](diffhunk://#diff-e141b8656df0ee831c8c03f2ab6b1cc3ec7f1c87776f9914b30227c0aed2a9b2L81-L82)
* Changed the grayscale preview texture from 8-bit (`r8OriginalGrayscale`) to 16-bit float (`r16fOriginalGrayscale`) throughout the debug window and rendering context for improved precision and consistency. [[1]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L35-R61) [[2]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L103-L111) [[3]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175R166-R171) [[4]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L185-R205) [[5]](diffhunk://#diff-e141b8656df0ee831c8c03f2ab6b1cc3ec7f1c87776f9914b30227c0aed2a9b2L65-R65)

**Debug Window Improvements:**

* Refactored the debug window's preview update logic to support displaying 16-bit float grayscale textures by converting them to 8-bit grayscale for visualization. Added a dedicated buffer for this conversion. [[1]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L277-R295) [[2]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L309-R308) [[3]](diffhunk://#diff-34bf3ca0b17aa4fc4d57d46e3e850ffc10cce286c10a8a48437fea417f9895c5R63-R69)

These changes streamline the filtering pipeline, improve performance by reducing passes, and make the debug tools more robust and accurate.