### PR TITLE
Ncnn interleave

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -9,4 +9,12 @@ filterLevelPassthrough="100 - Passthrough"
 filterLevelSegmentation="200 - Segmentation"
 filterLevelGuidedFilter="300 - Guided Filter"
 
+selfieSegmenterFps="Selfie Segmenter FPS"
+
+gfEpsFb="Guided Filter Eps [dB]"
+
+maskGamma="Mask Gamma"
+maskLowerBoundDb="Mask Lower Bound [dB]"
+maskUpperBoundMarginDb="Mask Upper Bound Margin [dB]"
+
 showDebugWindow="Show Debug Window"

--- a/data/locale/ja-JP.ini
+++ b/data/locale/ja-JP.ini
@@ -9,4 +9,12 @@ filterLevelPassthrough="100 - パススルー"
 filterLevelSegmentation="200 - セグメンテーション"
 filterLevelGuidedFilter="300 - ガイド付きフィルター"
 
+selfieSegmenterFps="セルフィセグメンターFPS"
+
+gfEpsFb="ガイド付きフィルターEps [dB]"
+
+maskGamma="マスクガンマ"
+maskLowerBoundDb="マスク下限 [dB]"
+maskUpperBoundMarginDb="マスク上限マージン [dB]"
+
 showDebugWindow="デバッグウィンドウを表示"

--- a/src/MainPluginContext.cpp
+++ b/src/MainPluginContext.cpp
@@ -93,6 +93,8 @@ void MainPluginContext::getDefaults(obs_data_t *data)
 {
 	obs_data_set_default_int(data, "filterLevel", static_cast<int>(FilterLevel::Default));
 
+	obs_data_set_default_int(data, "selfieSegmenterFps", 10);
+
 	obs_data_set_default_double(data, "gfEpsDb", -40.0);
 
 	obs_data_set_default_double(data, "maskGamma", 2.5);
@@ -123,6 +125,8 @@ obs_properties_t *MainPluginContext::getProperties()
 	obs_property_list_add_int(propFilterLevel, obs_module_text("filterLevelGuidedFilter"),
 				  static_cast<int>(FilterLevel::GuidedFilter));
 
+	obs_properties_add_int_slider(props, "selfieSegmenterFps", obs_module_text("selfieSegmenterFps"), 1, 30, 1);
+
 	obs_properties_add_float_slider(props, "gfEpsDb", obs_module_text("gfEpsFb"), -60.0, -20.0, 0.1);
 
 	obs_properties_add_float_slider(props, "maskGamma", obs_module_text("maskGamma"), 0.5, 3.0, 0.01);
@@ -148,6 +152,8 @@ obs_properties_t *MainPluginContext::getProperties()
 void MainPluginContext::update(obs_data_t *settings)
 {
 	preset.filterLevel = static_cast<FilterLevel>(obs_data_get_int(settings, "filterLevel"));
+
+	preset.selfieSegmenterFps = obs_data_get_int(settings, "selfieSegmenterFps");
 
 	preset.gfEpsDb = obs_data_get_double(settings, "gfEpsDb");
 	preset.gfEps = Preset::dbToLinearPow(preset.gfEpsDb);
@@ -218,8 +224,8 @@ try {
 		graphics_context_guard guard;
 		nextRenderingContext = std::make_shared<RenderingContext>(
 			source, logger, mainEffect, selfieSegmenterNet, selfieSegmenterTaskQueue, frame->width,
-			frame->height, preset.filterLevel, preset.gfEps, preset.maskGamma, preset.maskLowerBound,
-			preset.maskUpperBound);
+			frame->height, preset.filterLevel, preset.selfieSegmenterFps, preset.gfEps, preset.maskGamma,
+			preset.maskLowerBound, preset.maskUpperBound);
 		frameCountBeforeContextSwitch = 1;
 		gs_unique::drain();
 	}

--- a/src/MainPluginContext.cpp
+++ b/src/MainPluginContext.cpp
@@ -230,7 +230,11 @@ try {
 		gs_unique::drain();
 	}
 
-	return frame;
+	if (renderingContext) {
+		return renderingContext->filterVideo(frame);
+	} else {
+		return frame;
+	}
 } catch (const std::exception &e) {
 	logger.error("Failed to create rendering context: {}", e.what());
 	return frame;

--- a/src/Preset.hpp
+++ b/src/Preset.hpp
@@ -33,6 +33,8 @@ enum class FilterLevel : int {
 struct Preset {
 	FilterLevel filterLevel;
 
+	int selfieSegmenterFps;
+
 	double gfEpsDb;
 	double gfEps;
 

--- a/src/RenderingContext.cpp
+++ b/src/RenderingContext.cpp
@@ -236,10 +236,11 @@ void RenderingContext::videoRender()
 obs_source_frame *RenderingContext::filterVideo(obs_source_frame *frame)
 {
 	FilterLevel actualFilterLevel = filterLevel == FilterLevel::Default ? FilterLevel::GuidedFilter : filterLevel;
-		logger.info("Frame timestamp: {}, next segmentation timestamp: {}", frame->timestamp,
-			    previousSelfieSegmenterTimestamp);
+	logger.info("Frame timestamp: {}, next segmentation timestamp: {}", frame->timestamp,
+		    previousSelfieSegmenterTimestamp);
 	if (actualFilterLevel >= FilterLevel::Segmentation) {
-		const auto nextSelfieSegmenterTimestamp = previousSelfieSegmenterTimestamp + (1000000000 / selfieSegmenterFps);
+		const auto nextSelfieSegmenterTimestamp =
+			previousSelfieSegmenterTimestamp + (1000000000 / selfieSegmenterFps);
 
 		if (frame->timestamp >= nextSelfieSegmenterTimestamp) {
 			previousSelfieSegmenterTimestamp = frame->timestamp;

--- a/src/RenderingContext.cpp
+++ b/src/RenderingContext.cpp
@@ -50,8 +50,8 @@ namespace obs_backgroundremoval_lite {
 RenderingContext::RenderingContext(obs_source_t *_source, const ILogger &_logger, const MainEffect &_mainEffect,
 				   const ncnn::Net &_selfieSegmenterNet, ThrottledTaskQueue &_selfieSegmenterTaskQueue,
 				   std::uint32_t _width, std::uint32_t _height, const FilterLevel &_filterLevel,
-				   const double &_gfEps, const double &_maskGamma, const double &_maskLowerBound,
-				   const double &_maskUpperBound)
+				   const int &_selfieSegmenterFps, const double &_gfEps, const double &_maskGamma,
+				   const double &_maskLowerBound, const double &_maskUpperBound)
 	: source(_source),
 	  logger(_logger),
 	  mainEffect(_mainEffect),
@@ -83,6 +83,7 @@ RenderingContext::RenderingContext(obs_source_t *_source, const ILogger &_logger
 	  r8GFResult(make_unique_gs_texture(width, height, GS_R8, 1, NULL, GS_RENDER_TARGET)),
 	  r32fGFTemporary1Sub(make_unique_gs_texture(gfWidthSub, gfHeightSub, GS_R32F, 1, NULL, GS_RENDER_TARGET)),
 	  filterLevel(_filterLevel),
+	  selfieSegmenterFps(_selfieSegmenterFps),
 	  gfEps(_gfEps),
 	  maskGamma(_maskGamma),
 	  maskLowerBound(_maskLowerBound),
@@ -229,7 +230,6 @@ void RenderingContext::videoRender()
 
 	if (actualFilterLevel >= FilterLevel::Segmentation) {
 		readerSegmenterInput.stage(bgrxSegmenterInput.get());
-		kickSegmentationTask();
 	}
 }
 

--- a/src/RenderingContext.cpp
+++ b/src/RenderingContext.cpp
@@ -235,6 +235,18 @@ void RenderingContext::videoRender()
 
 obs_source_frame *RenderingContext::filterVideo(obs_source_frame *frame)
 {
+	FilterLevel actualFilterLevel = filterLevel == FilterLevel::Default ? FilterLevel::GuidedFilter : filterLevel;
+		logger.info("Frame timestamp: {}, next segmentation timestamp: {}", frame->timestamp,
+			    previousSelfieSegmenterTimestamp);
+	if (actualFilterLevel >= FilterLevel::Segmentation) {
+		const auto nextSelfieSegmenterTimestamp = previousSelfieSegmenterTimestamp + (1000000000 / selfieSegmenterFps);
+
+		if (frame->timestamp >= nextSelfieSegmenterTimestamp) {
+			previousSelfieSegmenterTimestamp = frame->timestamp;
+			kickSegmentationTask();
+		}
+	}
+
 	return frame;
 }
 

--- a/src/RenderingContext.hpp
+++ b/src/RenderingContext.hpp
@@ -82,6 +82,7 @@ private:
 	kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r32fGFTemporary1Sub;
 
 	const FilterLevel &filterLevel;
+	const int &selfieSegmenterFps;
 	const double &gfEps;
 	const double &maskGamma;
 	const double &maskLowerBound;
@@ -95,8 +96,8 @@ public:
 	RenderingContext(obs_source_t *source, const kaito_tokyo::obs_bridge_utils::ILogger &logger,
 			 const MainEffect &mainEffect, const ncnn::Net &selfieSegmenterNet,
 			 ThrottledTaskQueue &selfieSegmenterTaskQueue, std::uint32_t width, std::uint32_t height,
-			 const FilterLevel &filterLevel, const double &gfEps, const double &maskGamma,
-			 const double &maskLowerBound, const double &maskUpperBound);
+			 const FilterLevel &filterLevel, const int &selfieSegmenterFps, const double &gfEps,
+			 const double &maskGamma, const double &maskLowerBound, const double &maskUpperBound);
 	~RenderingContext() noexcept;
 
 	void videoTick(float seconds);

--- a/src/RenderingContext.hpp
+++ b/src/RenderingContext.hpp
@@ -43,6 +43,7 @@ private:
 	AsyncTextureReader readerSegmenterInput;
 	SelfieSegmenter selfieSegmenter;
 	ThrottledTaskQueue &selfieSegmenterTaskQueue;
+	std::uint64_t previousSelfieSegmenterTimestamp = 0;
 
 public:
 	const std::uint32_t width;


### PR DESCRIPTION
This pull request introduces a configurable frame rate for the selfie segmentation process, allowing users to control how often the segmentation runs per second. It also adds new UI controls and localization strings for this setting, along with some related parameter labels. The main changes are grouped below:

### Selfie Segmenter Frame Rate Configuration

* Added a new `selfieSegmenterFps` parameter to the `Preset` structure and made it configurable via the UI, with a default value of 10 FPS. This allows users to adjust the frequency of the selfie segmentation process. [[1]](diffhunk://#diff-db9241ee18be4160fe14f7f31a6f7a3c75599a9adc1eeb9692674c69c33a7b81R36-R37) [[2]](diffhunk://#diff-2d840159c3cd8f3bbc7cd26789596da8edde2415b7376f8de3d92403e91be39bR96-R97) [[3]](diffhunk://#diff-2d840159c3cd8f3bbc7cd26789596da8edde2415b7376f8de3d92403e91be39bR128-R129)
* Updated the `RenderingContext` class and its constructor to accept and store the new `selfieSegmenterFps` value, and to use it for throttling the segmentation task based on frame timestamps. [[1]](diffhunk://#diff-e141b8656df0ee831c8c03f2ab6b1cc3ec7f1c87776f9914b30227c0aed2a9b2L53-R54) [[2]](diffhunk://#diff-e141b8656df0ee831c8c03f2ab6b1cc3ec7f1c87776f9914b30227c0aed2a9b2R86) [[3]](diffhunk://#diff-95f698c2cdb5b41cd4071c9b0b0bfce87a4e459f054ce8669fbbe5b34c35e8b2R86) [[4]](diffhunk://#diff-95f698c2cdb5b41cd4071c9b0b0bfce87a4e459f054ce8669fbbe5b34c35e8b2L98-R101)
* Modified the video processing loop to trigger segmentation only at the configured frame rate, using timestamp checks and a new `previousSelfieSegmenterTimestamp` member. [[1]](diffhunk://#diff-e141b8656df0ee831c8c03f2ab6b1cc3ec7f1c87776f9914b30227c0aed2a9b2L232-R250) [[2]](diffhunk://#diff-95f698c2cdb5b41cd4071c9b0b0bfce87a4e459f054ce8669fbbe5b34c35e8b2R46)

### UI and Localization Updates

* Added new UI controls for `selfieSegmenterFps` (int slider), and updated or added labels for related parameters (`gfEpsFb`, `maskGamma`, `maskLowerBoundDb`, `maskUpperBoundMarginDb`) in both English and Japanese localization files. [[1]](diffhunk://#diff-b3c242ee2d502c9e6dade4bace60d2ea2ab52969dd96b1cac4ed42f60668b18aR12-R19) [[2]](diffhunk://#diff-4bfd334e089c6795ea16f2a141f4b50c012465a7ecc7f2b61288ab7394070493R12-R19) [[3]](diffhunk://#diff-2d840159c3cd8f3bbc7cd26789596da8edde2415b7376f8de3d92403e91be39bR128-R129)

### Integration and Data Flow

* Updated the main plugin context to handle the new parameter throughout the settings lifecycle, including setting defaults, updating presets, and passing the value to the rendering context. [[1]](diffhunk://#diff-2d840159c3cd8f3bbc7cd26789596da8edde2415b7376f8de3d92403e91be39bR96-R97) [[2]](diffhunk://#diff-2d840159c3cd8f3bbc7cd26789596da8edde2415b7376f8de3d92403e91be39bR156-R157) [[3]](diffhunk://#diff-2d840159c3cd8f3bbc7cd26789596da8edde2415b7376f8de3d92403e91be39bL221-R237)

These changes make the segmentation process more efficient and customizable, and improve the clarity and accessibility of related UI controls.