### PR TITLE
Update MainPluginContext.cpp

### DIFF
--- a/src/MainPluginContext.cpp
+++ b/src/MainPluginContext.cpp
@@ -40,6 +40,10 @@ MainPluginContext::MainPluginContext(obs_data_t *settings, obs_source_t *_source
 	  updateChecker(logger),
 	  selfieSegmenterTaskQueue(logger, 1)
 {
+	selfieSegmenterNet.opt.num_threads = 2;
+	selfieSegmenterNet.opt.use_local_pool_allocator = true;
+	selfieSegmenterNet.opt.openmp_blocktime = 1;
+
 	unique_bfree_char_t paramPath = unique_obs_module_file("models/mediapipe_selfie_segmentation_int8.ncnn.param");
 	if (!paramPath) {
 		throw std::runtime_error("Failed to find model param file");

--- a/src/RenderingContext.hpp
+++ b/src/RenderingContext.hpp
@@ -43,7 +43,6 @@ private:
 	AsyncTextureReader readerSegmenterInput;
 	SelfieSegmenter selfieSegmenter;
 	ThrottledTaskQueue &selfieSegmenterTaskQueue;
-	std::uint64_t previousSelfieSegmenterTimestamp = 0;
 
 public:
 	const std::uint32_t width;
@@ -88,6 +87,8 @@ private:
 	const double &maskGamma;
 	const double &maskLowerBound;
 	const double &maskUpperBound;
+
+	float timeSinceLastSelfieSegmentation = 0.0f;
 
 	vec4 blackColor = {0.0f, 0.0f, 0.0f, 1.0f};
 


### PR DESCRIPTION
This pull request refactors how the selfie segmentation task is triggered within the video processing pipeline. The main change is moving from a timestamp-based approach to a time-accumulation approach for scheduling segmentation, which simplifies the logic and improves maintainability. Additionally, it introduces configuration improvements for the segmentation network and some minor code cleanups.

**Selfie segmentation scheduling refactor:**

* Replaced the timestamp-based logic for triggering selfie segmentation in `RenderingContext::filterVideo` with a time-accumulation mechanism in `RenderingContext::videoTick`, using a new `timeSinceLastSelfieSegmentation` member to control task scheduling at the configured FPS. [[1]](diffhunk://#diff-e141b8656df0ee831c8c03f2ab6b1cc3ec7f1c87776f9914b30227c0aed2a9b2L99-R109) [[2]](diffhunk://#diff-e141b8656df0ee831c8c03f2ab6b1cc3ec7f1c87776f9914b30227c0aed2a9b2L238-L250) [[3]](diffhunk://#diff-95f698c2cdb5b41cd4071c9b0b0bfce87a4e459f054ce8669fbbe5b34c35e8b2L46) [[4]](diffhunk://#diff-95f698c2cdb5b41cd4071c9b0b0bfce87a4e459f054ce8669fbbe5b34c35e8b2R91-R92)

**Selfie segmentation network configuration:**

* Set additional options for the `selfieSegmenterNet` in the `MainPluginContext` constructor, including number of threads, use of a local pool allocator, and OpenMP blocktime, to improve performance and resource management.