### PR TITLE
Adaptive interence 2

### DIFF
--- a/data/effects/main.effect
+++ b/data/effects/main.effect
@@ -144,6 +144,55 @@ float4 PSConvertToGrayscale(VertInOut vert_in) : TARGET
 }
 
 /**
+ * @brief Calculates the difference between two grayscale images, considering a mask, for the first pass of a reduction.
+ * @details This shader computes the absolute luminance difference between the current and last frames,
+ * but only for regions where the mask value is greater than 0.1 (likely the subject).
+ * This isolates changes related to the subject's movement and ignores background noise.
+ * @param image  Input texture (current downsampled grayscale image).
+ * @param image1 Input texture (last downsampled grayscale image).
+ * @param image2 Input texture (segmentation mask).
+ * @return Returns the luminance difference for pixels within the masked area; otherwise, returns black (0).
+ */
+float4 PSCalculateMaskedDifferenceR(VertInOut vert_in) : TARGET
+{
+	float2 uv = vert_in.uv;
+
+	float current_luma = image.Sample(point_sampler, uv).r;
+	float last_luma    = image1.Sample(point_sampler, uv).r;
+	float mask         = image2.Sample(point_sampler, uv).r;
+
+	float weight = step(0.1, mask);
+
+	float diff = abs(current_luma - last_luma);
+
+	float final_diff = diff * weight;
+
+	return float4(final_diff, final_diff, final_diff, 1.0f);
+}
+
+/**
+ * @brief Reduces a texture by summing 2x2 pixel blocks using an optimized bilinear sample.
+ * @details This shader downsamples an input texture to half its size. It calculates the sum
+ * of a 2x2 pixel block by performing a single bilinear texture fetch from the center of the block,
+ * which returns the average of the four pixels. This average is then multiplied by 4 to get the sum.
+ * This method significantly reduces texture fetches from 4 to 1 per pixel.
+ * @param image Input texture to be reduced. The .r channel is expected to contain the value.
+ * @return The sum of a 2x2 block of pixels, stored in all RGBA channels.
+ */
+float4 PSReduce(VertInOut vert_in) : TARGET
+{
+	// A single bilinear sample from the center of a 2x2 texel area
+	// returns the average of those four texels. The C++ side ensures the UV
+	// coordinates align correctly for this operation.
+	float average = image.Sample(linear_sampler, vert_in.uv).r;
+
+	// Multiply the average by 4.0 to get the sum.
+	float sum = average * 4.0;
+
+	return float4(sum, sum, sum, 1.0f);
+}
+
+/**
  * @brief Applies an optimized 1D horizontal box filter with a fixed kernel size of 17.
  * (Pass 1 of a separable filter)
  */
@@ -349,6 +398,24 @@ technique ConvertToGrayscale
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader = PSConvertToGrayscale(vert_in);
+	}
+}
+
+technique CalculateDifferenceWithMask
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader = PSCalculateMaskedDifferenceR(vert_in);
+	}
+}
+
+technique Reduce
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader = PSReduce(vert_in);
 	}
 }
 

--- a/src/DebugWindow.cpp
+++ b/src/DebugWindow.cpp
@@ -33,10 +33,11 @@ namespace {
 
 constexpr char textureBgrxOriginalImage[] = "bgrxOriginalImage";
 constexpr char textureR32fOriginalGrayscale[] = "r32fOriginalGrayscale";
-constexpr char textureR32fSubOriginalGrayscale[] = "r32fSubOriginalGrayscale";
-constexpr char textureR32fSubLastOriginalGrayscale[] = "r32fSubLastOriginalGrayscale";
 constexpr char textureBgrxSegmenterInput[] = "bgrxSegmenterInput";
 constexpr char textureR8SegmentationMask[] = "r8SegmentationMask";
+constexpr char textureR32fSubOriginalGrayscale[] = "r32fSubOriginalGrayscale";
+constexpr char textureR32fSubLastOriginalGrayscale[] = "r32fSubLastOriginalGrayscale";
+constexpr char textureR32fSubDifferenceWithMask[] = "r32fSubDifferenceWithMask";
 constexpr char textureR8SubGFGuide[] = "r8SubGFGuide";
 constexpr char textureR8SubGFSource[] = "r8SubGFSource";
 constexpr char textureR32fSubGFMeanGuide[] = "r32fSubGFMeanGuide";
@@ -55,6 +56,7 @@ const std::vector<std::string> r8MaskRoiTextures = {textureR8SegmentationMask};
 const std::vector<std::string> r8SubTextures = {textureR8SubGFGuide, textureR8SubGFSource};
 const std::vector<std::string> r32fSubTextures = {textureR32fSubOriginalGrayscale,
 						  textureR32fSubLastOriginalGrayscale,
+						  textureR32fSubDifferenceWithMask,
 						  textureR32fSubGFMeanGuide,
 						  textureR32fSubGFMeanSource,
 						  textureR16fSubGFMeanGuideSource,
@@ -116,10 +118,11 @@ DebugWindow::DebugWindow(std::weak_ptr<MainPluginContext> _weakMainPluginContext
 {
 	previewTextureSelector->addItem(textureBgrxOriginalImage);
 	previewTextureSelector->addItem(textureR32fOriginalGrayscale);
-	previewTextureSelector->addItem(textureR32fSubOriginalGrayscale);
-	previewTextureSelector->addItem(textureR32fSubLastOriginalGrayscale);
 	previewTextureSelector->addItem(textureBgrxSegmenterInput);
 	previewTextureSelector->addItem(textureR8SegmentationMask);
+	previewTextureSelector->addItem(textureR32fSubOriginalGrayscale);
+	previewTextureSelector->addItem(textureR32fSubLastOriginalGrayscale);
+	previewTextureSelector->addItem(textureR32fSubDifferenceWithMask);
 	previewTextureSelector->addItem(textureR8SubGFGuide);
 	previewTextureSelector->addItem(textureR8SubGFSource);
 	previewTextureSelector->addItem(textureR32fSubGFMeanGuide);
@@ -203,18 +206,21 @@ void DebugWindow::videoRender()
 		} else if (currentTexture == textureR32fOriginalGrayscale) {
 			readerR32f->sync();
 			readerR32f->stage(renderingContext->r32fOriginalGrayscale.get());
-		} else if (currentTexture == textureR32fSubOriginalGrayscale) {
-			readerR32fSub->sync();
-			readerR32fSub->stage(renderingContext->r32fSubOriginalGrayscale.get());
-		} else if (currentTexture == textureR32fSubLastOriginalGrayscale) {
-			readerR32fSub->sync();
-			readerR32fSub->stage(renderingContext->r32fSubLastOriginalGrayscale.get());
 		} else if (currentTexture == textureBgrxSegmenterInput) {
 			reader256Bgrx->sync();
 			reader256Bgrx->stage(renderingContext->bgrxSegmenterInput.get());
 		} else if (currentTexture == textureR8SegmentationMask) {
 			readerMaskRoiR8->sync();
 			readerMaskRoiR8->stage(renderingContext->r8SegmentationMask.get());
+		} else if (currentTexture == textureR32fSubOriginalGrayscale) {
+			readerR32fSub->sync();
+			readerR32fSub->stage(renderingContext->r32fSubOriginalGrayscale.get());
+		} else if (currentTexture == textureR32fSubLastOriginalGrayscale) {
+			readerR32fSub->sync();
+			readerR32fSub->stage(renderingContext->r32fSubLastOriginalGrayscale.get());
+		} else if (currentTexture == textureR32fSubDifferenceWithMask) {
+			readerR32fSub->sync();
+			readerR32fSub->stage(renderingContext->r32fSubDifferenceWithMask.get());
 		} else if (currentTexture == textureR8SubGFGuide) {
 			readerSubR8->sync();
 			readerSubR8->stage(renderingContext->r8SubGFGuide.get());

--- a/src/DebugWindow.cpp
+++ b/src/DebugWindow.cpp
@@ -35,8 +35,8 @@ constexpr char textureBgrxOriginalImage[] = "bgrxOriginalImage";
 constexpr char textureR32fOriginalGrayscale[] = "r32fOriginalGrayscale";
 constexpr char textureBgrxSegmenterInput[] = "bgrxSegmenterInput";
 constexpr char textureR8SegmentationMask[] = "r8SegmentationMask";
-constexpr char textureR32fSubOriginalGrayscale[] = "r32fSubOriginalGrayscale";
-constexpr char textureR32fSubLastOriginalGrayscale[] = "r32fSubLastOriginalGrayscale";
+constexpr char textureR32fSubOriginalGrayscales0[] = "r32fSubOriginalGrayscales[0]";
+constexpr char textureR32fSubOriginalGrayscales1[] = "r32fSubOriginalGrayscales[1]";
 constexpr char textureR32fSubDifferenceWithMask[] = "r32fSubDifferenceWithMask";
 constexpr char textureR8SubGFGuide[] = "r8SubGFGuide";
 constexpr char textureR8SubGFSource[] = "r8SubGFSource";
@@ -54,8 +54,8 @@ const std::vector<std::string> r32fTextures = {textureR32fOriginalGrayscale};
 const std::vector<std::string> bgrx256Textures = {textureBgrxSegmenterInput};
 const std::vector<std::string> r8MaskRoiTextures = {textureR8SegmentationMask};
 const std::vector<std::string> r8SubTextures = {textureR8SubGFGuide, textureR8SubGFSource};
-const std::vector<std::string> r32fSubTextures = {textureR32fSubOriginalGrayscale,
-						  textureR32fSubLastOriginalGrayscale,
+const std::vector<std::string> r32fSubTextures = {textureR32fSubOriginalGrayscales0,
+						  textureR32fSubOriginalGrayscales1,
 						  textureR32fSubDifferenceWithMask,
 						  textureR32fSubGFMeanGuide,
 						  textureR32fSubGFMeanSource,
@@ -120,8 +120,8 @@ DebugWindow::DebugWindow(std::weak_ptr<MainPluginContext> _weakMainPluginContext
 	previewTextureSelector->addItem(textureR32fOriginalGrayscale);
 	previewTextureSelector->addItem(textureBgrxSegmenterInput);
 	previewTextureSelector->addItem(textureR8SegmentationMask);
-	previewTextureSelector->addItem(textureR32fSubOriginalGrayscale);
-	previewTextureSelector->addItem(textureR32fSubLastOriginalGrayscale);
+	previewTextureSelector->addItem(textureR32fSubOriginalGrayscales0);
+	previewTextureSelector->addItem(textureR32fSubOriginalGrayscales1);
 	previewTextureSelector->addItem(textureR32fSubDifferenceWithMask);
 	previewTextureSelector->addItem(textureR8SubGFGuide);
 	previewTextureSelector->addItem(textureR8SubGFSource);
@@ -143,7 +143,7 @@ DebugWindow::DebugWindow(std::weak_ptr<MainPluginContext> _weakMainPluginContext
 	setLayout(layout);
 
 	connect(updateTimer, &QTimer::timeout, this, &DebugWindow::updatePreview);
-	updateTimer->start(100); // 約30fpsで更新
+	updateTimer->start(1000 / 60); // 約30fpsで更新
 
 	connect(this, &DebugWindow::readerReady, this, &DebugWindow::updatePreview);
 }
@@ -212,12 +212,12 @@ void DebugWindow::videoRender()
 		} else if (currentTexture == textureR8SegmentationMask) {
 			readerMaskRoiR8->sync();
 			readerMaskRoiR8->stage(renderingContext->r8SegmentationMask.get());
-		} else if (currentTexture == textureR32fSubOriginalGrayscale) {
+		} else if (currentTexture == textureR32fSubOriginalGrayscales0) {
 			readerR32fSub->sync();
-			readerR32fSub->stage(renderingContext->r32fSubOriginalGrayscale.get());
-		} else if (currentTexture == textureR32fSubLastOriginalGrayscale) {
+			readerR32fSub->stage(renderingContext->r32fSubOriginalGrayscales[0].get());
+		} else if (currentTexture == textureR32fSubOriginalGrayscales1) {
 			readerR32fSub->sync();
-			readerR32fSub->stage(renderingContext->r32fSubLastOriginalGrayscale.get());
+			readerR32fSub->stage(renderingContext->r32fSubOriginalGrayscales[1].get());
 		} else if (currentTexture == textureR32fSubDifferenceWithMask) {
 			readerR32fSub->sync();
 			readerR32fSub->stage(renderingContext->r32fSubDifferenceWithMask.get());

--- a/src/MainEffect.hpp
+++ b/src/MainEffect.hpp
@@ -302,10 +302,8 @@ public:
 		gs_technique_end(tech);
 	}
 
-	void reduce(
-		std::uint32_t width, std::uint32_t height,
-		const std::vector<kaito_tokyo::obs_bridge_utils::unique_gs_texture_t> &reductionPyramidTextures,
-		const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t &sourceTexture) const noexcept
+	void reduce(const std::vector<kaito_tokyo::obs_bridge_utils::unique_gs_texture_t> &reductionPyramidTextures,
+		    const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t &sourceTexture) const noexcept
 	{
 		RenderTargetGuard renderTargetGuard;
 		TransformStateGuard transformStateGuard;
@@ -321,7 +319,8 @@ public:
 
 			gs_set_render_target_with_color_space(currentTarget, nullptr, GS_CS_SRGB);
 			gs_set_viewport(0, 0, targetWidth, targetHeight);
-			gs_ortho(0.0f, static_cast<float>(targetWidth), 0.0f, static_cast<float>(targetHeight), -100.0f, 100.0f);
+			gs_ortho(0.0f, static_cast<float>(targetWidth), 0.0f, static_cast<float>(targetHeight), -100.0f,
+				 100.0f);
 			gs_matrix_identity();
 
 			std::size_t passes = gs_technique_begin(tech);
@@ -330,7 +329,7 @@ public:
 					gs_effect_set_texture(textureImage, currentSource);
 
 					gs_draw_sprite(nullptr, 0, targetWidth, targetHeight);
-					
+
 					gs_technique_end_pass(tech);
 				}
 			}

--- a/src/RenderingContext.hpp
+++ b/src/RenderingContext.hpp
@@ -54,8 +54,7 @@ public:
 public:
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t bgrxOriginalImage;
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r32fOriginalGrayscale;
-	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r32fSubOriginalGrayscale;
-	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r32fSubLastOriginalGrayscale;
+
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t bgrxSegmenterInput;
 
 private:
@@ -68,6 +67,11 @@ public:
 	const std::uint32_t maskRoiHeight;
 
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r8SegmentationMask;
+
+	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r32fSubOriginalGrayscale;
+	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r32fSubLastOriginalGrayscale;
+	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r32fSubDifferenceWithMask;
+	const std::vector<kaito_tokyo::obs_bridge_utils::unique_gs_texture_t> r32fSubReductionPyramid;
 
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r8SubGFGuide;
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r8SubGFSource;
@@ -110,6 +114,7 @@ private:
 	void renderOriginalGrayscale(gs_texture_t *bgrxOriginalImage);
 	void renderSegmenterInput(gs_texture_t *bgrxOriginalImage);
 	void renderSegmentationMask();
+	void calculateDifferenceWithMask();
 	void renderGuidedFilter(gs_texture_t *r16fOriginalGrayscale, gs_texture_t *r8SegmentationMask);
 	void kickSegmentationTask();
 };

--- a/src/RenderingContext.hpp
+++ b/src/RenderingContext.hpp
@@ -18,6 +18,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 
 #include <net.h>
@@ -68,10 +69,10 @@ public:
 
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r8SegmentationMask;
 
-	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r32fSubOriginalGrayscale;
-	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r32fSubLastOriginalGrayscale;
+	std::array<kaito_tokyo::obs_bridge_utils::unique_gs_texture_t, 2> r32fSubOriginalGrayscales;
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r32fSubDifferenceWithMask;
-	const std::vector<kaito_tokyo::obs_bridge_utils::unique_gs_texture_t> r32fSubReductionPyramid;
+	const std::vector<kaito_tokyo::obs_bridge_utils::unique_gs_texture_t> r32fSubDifferenceWithMaskReductionPyramid;
+	AsyncTextureReader readerReducedSubDifferenceWithMask;
 
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r8SubGFGuide;
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r8SubGFSource;


### PR DESCRIPTION
This pull request introduces a new masked difference calculation and reduction pipeline for grayscale images, refactors how downsampled grayscale textures are managed, and updates the debug interface to support these changes. The main goals are to efficiently compute and summarize the difference between consecutive frames in regions of interest (as defined by a segmentation mask), and to streamline texture handling for these operations.

Key changes:

### Masked Difference and Reduction Pipeline

* Added the `PSCalculateMaskedDifferenceR` and `PSReduce` pixel shaders and corresponding `CalculateDifferenceWithMask` and `Reduce` techniques to `main.effect`, enabling efficient masked difference computation and hierarchical reduction of textures. [[1]](diffhunk://#diff-0b18719285445723753d3b029041900a3f6c64c9aba22c47c82f152aec10127aR146-R194) [[2]](diffhunk://#diff-0b18719285445723753d3b029041900a3f6c64c9aba22c47c82f152aec10127aR404-R421)
* Implemented `calculateDifferenceWithMask` and `reduce` methods in `MainEffect`, and integrated their usage into the `RenderingContext::calculateDifferenceWithMask` workflow, including a reduction pyramid for summarizing differences. [[1]](diffhunk://#diff-ea152ee3ce682ff357aa697a7be8025c477f2845fa2361d7dbe4e7315f737ca2R118-R119) [[2]](diffhunk://#diff-ea152ee3ce682ff357aa697a7be8025c477f2845fa2361d7dbe4e7315f737ca2R148-R150) [[3]](diffhunk://#diff-ea152ee3ce682ff357aa697a7be8025c477f2845fa2361d7dbe4e7315f737ca2R275-R341) [[4]](diffhunk://#diff-e141b8656df0ee831c8c03f2ab6b1cc3ec7f1c87776f9914b30227c0aed2a9b2R46-R65) [[5]](diffhunk://#diff-e141b8656df0ee831c8c03f2ab6b1cc3ec7f1c87776f9914b30227c0aed2a9b2R96-R102) [[6]](diffhunk://#diff-e141b8656df0ee831c8c03f2ab6b1cc3ec7f1c87776f9914b30227c0aed2a9b2R189-R198)

### Texture Management Refactor

* Replaced individual downsampled grayscale textures (`r32fSubOriginalGrayscale`, `r32fSubLastOriginalGrayscale`) with an array (`r32fSubOriginalGrayscales[2]`) and a dedicated difference texture (`r32fSubDifferenceWithMask`), including a reduction pyramid for the latter. [[1]](diffhunk://#diff-e141b8656df0ee831c8c03f2ab6b1cc3ec7f1c87776f9914b30227c0aed2a9b2L67-L68) [[2]](diffhunk://#diff-95f698c2cdb5b41cd4071c9b0b0bfce87a4e459f054ce8669fbbe5b34c35e8b2L57-R58)
* Updated all references, logic, and debug window texture selectors to use the new texture names and structures. [[1]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L36-R40) [[2]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L56-R59) [[3]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L119-R125) [[4]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L206-R223)

### Debug and UI Improvements

* Updated the debug window to allow previewing the new and updated textures, and fixed the update timer interval calculation for smoother UI refresh. [[1]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L119-R125) [[2]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L143-R146)
* Enhanced logging in `RenderingContext::videoRender` to report the reduced masked difference value for debugging and monitoring. [[1]](diffhunk://#diff-e141b8656df0ee831c8c03f2ab6b1cc3ec7f1c87776f9914b30227c0aed2a9b2R251-R259) [[2]](diffhunk://#diff-e141b8656df0ee831c8c03f2ab6b1cc3ec7f1c87776f9914b30227c0aed2a9b2R292)

These changes collectively enable more robust and efficient per-frame difference analysis in masked regions, simplify texture management, and improve the developer debugging experience.