### PR TITLE
Render video only on new frame arrival

### DIFF
--- a/src/RenderingContext.cpp
+++ b/src/RenderingContext.cpp
@@ -42,6 +42,26 @@ std::array<std::uint32_t, 4> getMaskRoiDimension(std::uint32_t width, std::uint3
 	return {offsetX, offsetY, scaledWidth, scaledHeight};
 }
 
+inline std::vector<kaito_tokyo::obs_bridge_utils::unique_gs_texture_t> createReductionPyramid(std::uint32_t width,
+											      std::uint32_t height)
+{
+	using namespace kaito_tokyo::obs_bridge_utils;
+	std::vector<unique_gs_texture_t> pyramid;
+
+	std::uint32_t currentWidth = width;
+	std::uint32_t currentHeight = height;
+
+	while (currentWidth > 1 || currentHeight > 1) {
+		currentWidth = std::max(1u, (currentWidth + 1) / 2);
+		currentHeight = std::max(1u, (currentHeight + 1) / 2);
+
+		pyramid.push_back(
+			make_unique_gs_texture(currentWidth, currentHeight, GS_R32F, 1, NULL, GS_RENDER_TARGET));
+	}
+
+	return pyramid;
+}
+
 } // anonymous namespace
 
 namespace kaito_tokyo {
@@ -64,8 +84,6 @@ RenderingContext::RenderingContext(obs_source_t *_source, const ILogger &_logger
 	  heightSub(height / subsamplingRate),
 	  bgrxOriginalImage(make_unique_gs_texture(width, height, GS_BGRX, 1, NULL, GS_RENDER_TARGET)),
 	  r32fOriginalGrayscale(make_unique_gs_texture(width, height, GS_R32F, 1, NULL, GS_RENDER_TARGET)),
-	  r32fSubOriginalGrayscale(make_unique_gs_texture(widthSub, heightSub, GS_R32F, 1, NULL, GS_RENDER_TARGET)),
-	  r32fSubLastOriginalGrayscale(make_unique_gs_texture(widthSub, heightSub, GS_R32F, 1, NULL, 0)),
 	  bgrxSegmenterInput(make_unique_gs_texture(SelfieSegmenter::INPUT_WIDTH, SelfieSegmenter::INPUT_HEIGHT,
 						    GS_BGRX, 1, NULL, GS_RENDER_TARGET)),
 	  segmenterInputBuffer(SelfieSegmenter::PIXEL_COUNT * 4),
@@ -74,6 +92,11 @@ RenderingContext::RenderingContext(obs_source_t *_source, const ILogger &_logger
 	  maskRoiWidth(getMaskRoiDimension(width, height)[2]),
 	  maskRoiHeight(getMaskRoiDimension(width, height)[3]),
 	  r8SegmentationMask(make_unique_gs_texture(maskRoiWidth, maskRoiHeight, GS_R8, 1, NULL, GS_DYNAMIC)),
+	  r32fSubOriginalGrayscales{make_unique_gs_texture(widthSub, heightSub, GS_R32F, 1, NULL, GS_RENDER_TARGET),
+				    make_unique_gs_texture(widthSub, heightSub, GS_R32F, 1, NULL, GS_RENDER_TARGET)},
+	  r32fSubDifferenceWithMask(make_unique_gs_texture(widthSub, heightSub, GS_R32F, 1, NULL, GS_RENDER_TARGET)),
+	  r32fSubDifferenceWithMaskReductionPyramid(createReductionPyramid(widthSub, heightSub)),
+	  readerReducedDifferenceWithMask(1, 1, GS_R32F),
 	  r8SubGFGuide(make_unique_gs_texture(widthSub, heightSub, GS_R8, 1, NULL, GS_RENDER_TARGET)),
 	  r8SubGFSource(make_unique_gs_texture(widthSub, heightSub, GS_R8, 1, NULL, GS_RENDER_TARGET)),
 	  r32fSubGFMeanGuide(make_unique_gs_texture(widthSub, heightSub, GS_R32F, 1, NULL, GS_RENDER_TARGET)),
@@ -98,6 +121,8 @@ RenderingContext::~RenderingContext() noexcept {}
 void RenderingContext::videoTick(float seconds)
 {
 	FilterLevel actualFilterLevel = filterLevel == FilterLevel::Default ? FilterLevel::GuidedFilter : filterLevel;
+	logger.info("Difference {}",
+		    reinterpret_cast<const float *>(readerReducedDifferenceWithMask.getBuffer().data())[0]);
 
 	if (actualFilterLevel >= FilterLevel::Segmentation) {
 		timeSinceLastSelfieSegmentation += seconds;
@@ -132,10 +157,8 @@ void RenderingContext::renderOriginalImage()
 
 void RenderingContext::renderOriginalGrayscale(gs_texture_t *bgrxOriginalImage)
 {
-	gs_copy_texture(r32fSubLastOriginalGrayscale.get(), r32fSubOriginalGrayscale.get());
-
 	mainEffect.convertToGrayscale(width, height, r32fOriginalGrayscale.get(), bgrxOriginalImage);
-	mainEffect.resampleByNearestR8(widthSub, heightSub, r32fSubOriginalGrayscale.get(),
+	mainEffect.resampleByNearestR8(widthSub, heightSub, r32fSubOriginalGrayscales[0].get(),
 				       r32fOriginalGrayscale.get());
 }
 
@@ -160,6 +183,16 @@ void RenderingContext::renderSegmentationMask()
 	const std::uint8_t *segmentationMaskData =
 		selfieSegmenter.getMask().data() + (maskRoiOffsetY * SelfieSegmenter::INPUT_WIDTH + maskRoiOffsetX);
 	gs_texture_set_image(r8SegmentationMask.get(), segmentationMaskData, SelfieSegmenter::INPUT_WIDTH, 0);
+}
+
+void RenderingContext::calculateDifferenceWithMask()
+{
+	mainEffect.calculateDifferenceWithMask(widthSub, heightSub, r32fSubDifferenceWithMask,
+					       r32fSubOriginalGrayscales[0], r32fSubOriginalGrayscales[1],
+					       r8SegmentationMask);
+
+	mainEffect.reduce(r32fSubDifferenceWithMaskReductionPyramid, r32fSubDifferenceWithMask);
+	std::swap(r32fSubOriginalGrayscales[0], r32fSubOriginalGrayscales[1]);
 }
 
 void RenderingContext::renderGuidedFilter(gs_texture_t *r16fOriginalGrayscale, gs_texture_t *r8SegmentationMask)
@@ -214,6 +247,7 @@ void RenderingContext::videoRender()
 		if (actualFilterLevel >= FilterLevel::Segmentation) {
 			try {
 				readerSegmenterInput.sync();
+				readerReducedDifferenceWithMask.sync();
 			} catch (const std::exception &e) {
 				logger.error("Failed to sync texture reader: {}", e.what());
 			}
@@ -228,6 +262,7 @@ void RenderingContext::videoRender()
 		if (actualFilterLevel >= FilterLevel::Segmentation) {
 			renderSegmenterInput(bgrxOriginalImage.get());
 			renderSegmentationMask();
+			calculateDifferenceWithMask();
 		}
 
 		if (actualFilterLevel >= FilterLevel::GuidedFilter) {
@@ -249,6 +284,7 @@ void RenderingContext::videoRender()
 
 	if (actualFilterLevel >= FilterLevel::Segmentation) {
 		readerSegmenterInput.stage(bgrxSegmenterInput.get());
+		readerReducedDifferenceWithMask.stage(r32fSubDifferenceWithMaskReductionPyramid.back().get());
 	}
 }
 

--- a/src/RenderingContext.hpp
+++ b/src/RenderingContext.hpp
@@ -90,6 +90,8 @@ private:
 	const double &maskUpperBound;
 
 	float timeSinceLastSelfieSegmentation = 0.0f;
+	std::uint64_t lastFrameTimestamp = 0;
+	bool doesNextVideoRenderReceiveNewFrame = false;
 
 	vec4 blackColor = {0.0f, 0.0f, 0.0f, 1.0f};
 

--- a/src/RenderingContext.hpp
+++ b/src/RenderingContext.hpp
@@ -19,6 +19,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 
 #include <net.h>
@@ -72,8 +73,11 @@ public:
 	std::array<kaito_tokyo::obs_bridge_utils::unique_gs_texture_t, 2> r32fSubOriginalGrayscales;
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r32fSubDifferenceWithMask;
 	const std::vector<kaito_tokyo::obs_bridge_utils::unique_gs_texture_t> r32fSubDifferenceWithMaskReductionPyramid;
-	AsyncTextureReader readerReducedSubDifferenceWithMask;
 
+private:
+	AsyncTextureReader readerReducedDifferenceWithMask;
+
+public:
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r8SubGFGuide;
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r8SubGFSource;
 	const kaito_tokyo::obs_bridge_utils::unique_gs_texture_t r32fSubGFMeanGuide;
@@ -96,7 +100,7 @@ private:
 
 	float timeSinceLastSelfieSegmentation = 0.0f;
 	std::uint64_t lastFrameTimestamp = 0;
-	bool doesNextVideoRenderReceiveNewFrame = false;
+	std::atomic<bool> doesNextVideoRenderReceiveNewFrame = false;
 
 	vec4 blackColor = {0.0f, 0.0f, 0.0f, 1.0f};
 


### PR DESCRIPTION
This pull request improves the efficiency and correctness of video frame processing in the `RenderingContext` class by introducing logic to track and handle new video frames. The main changes ensure that video rendering only processes new frames and avoids redundant computations.

**Video frame processing improvements:**

* Added `lastFrameTimestamp` and `doesNextVideoRenderReceiveNewFrame` member variables to `RenderingContext` to track the arrival of new video frames.
* Updated `filterVideo()` to check if the incoming frame is new based on its timestamp, setting `doesNextVideoRenderReceiveNewFrame` accordingly and updating `lastFrameTimestamp`. Also added a null check for input frames.

**Rendering logic adjustments:**

* Modified `videoRender()` to only perform frame processing steps when a new frame has been received, resetting the flag after processing.
* Ensured that rendering steps for guided filtering and segmentation are only executed for new frames, preventing unnecessary repeated processing.Added logic to track the last processed frame timestamp and a flag to ensure videoRender only processes when a new frame is received. This prevents redundant rendering and improves efficiency by skipping rendering steps if the frame has not changed.