### PR TITLE
Update RenderingContext.cpp

### DIFF
--- a/src/RenderingContext.cpp
+++ b/src/RenderingContext.cpp
@@ -121,8 +121,6 @@ RenderingContext::~RenderingContext() noexcept {}
 void RenderingContext::videoTick(float seconds)
 {
 	FilterLevel actualFilterLevel = filterLevel == FilterLevel::Default ? FilterLevel::GuidedFilter : filterLevel;
-	logger.info("Difference {}",
-		    reinterpret_cast<const float *>(readerReducedDifferenceWithMask.getBuffer().data())[0]);
 
 	if (actualFilterLevel >= FilterLevel::Segmentation) {
 		timeSinceLastSelfieSegmentation += seconds;


### PR DESCRIPTION
This pull request makes a small change to the `RenderingContext` class by removing an unnecessary logging statement from the `videoTick` method. This helps to reduce log noise and improve performance.

- Removed a debug logging statement from the `videoTick` method in `RenderingContext.cpp` to clean up the logs.