### PR TITLE
Add pkgbuild 3

### DIFF
--- a/unsupported/arch/obs-backgroundremoval-lite-git/PKGBUILD
+++ b/unsupported/arch/obs-backgroundremoval-lite-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Kaito Udagawa <umireon at kaito dot tokyo>
 pkgname=obs-backgroundremoval-lite-git
 _pkgname="${pkgname%-git}"
-pkgver=1.4.3
+pkgver=1.4.2.r6.g93e83e6
 pkgrel=1
 pkgdesc='Background Removal Lite for OBS Studio'
 arch=(x86_64)


### PR DESCRIPTION
This pull request updates the packaging for `obs-backgroundremoval-lite-git` by renaming its directory and making several adjustments to the build configuration and versioning.

Directory and versioning changes:
* Renamed the package directory from `unsupported/aur/obs-backgroundremoval-lite-git` to `unsupported/arch/obs-backgroundremoval-lite-git` to reflect its new location.
* Updated the `pkgver` to `1.4.2.r6.g93e83e6` to reflect the latest commit-based versioning scheme.

Build system improvements:
* Added `-DENABLE_FRONTEND_API=ON` and `-DENABLE_QT=ON` to the CMake build options in the `build()` function to enable additional features during the build.