### PR TITLE
Update GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -59,6 +59,12 @@ To initiate a new release, the user will instruct Gemini to start the process (e
     *   **ACTION**: Provide the releases URL.
     *   **INSTRUCTION**: User completes the release on GitHub.
 
+6.  **Update PKGBUILD for Arch Linux**:
+    *   **ACTION**: Match the `pkgver` field in `unsupported/arch/obs-backgroundremoval-lite/PKGBUILD` with the version in `buildspec.json`.
+    *   **ACTION**: Download the source tar.gz for that version from GitHub and calculate its SHA-256 checksum.
+    *   **ACTION**: Replace the `sha256sums` field in `unsupported/arch/obs-backgroundremoval-lite/PKGBUILD` with the newly calculated SHA-256 checksum.
+    *   **ACTION**: Commit the changes and create a pull request.
+
 **Example Interaction:**
 
 User: `リリースを開始して`


### PR DESCRIPTION
This pull request updates the release process documentation by adding instructions for updating the Arch Linux PKGBUILD file as part of the release workflow. The new steps ensure that the PKGBUILD version and checksum are kept in sync with the release.

Release process documentation updates:

* Added a new step to update the `pkgver` field in `unsupported/arch/obs-backgroundremoval-lite/PKGBUILD` to match the version in `buildspec.json`.
* Added instructions to download the source tarball for the matched version, calculate its SHA-256 checksum, and update the `sha256sums` field in the PKGBUILD file.
* Included steps to commit these changes and create a pull request as part of the release process.