### PR TITLE
Update index.astro

### DIFF
--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -17,15 +17,15 @@ const tagName = release.tag_name;
   </p>
   <div class="links">
     <a
-      href=`https://github.com/kaito-tokyo/obs-backgroundremoval-lite/releases/download/${tagName}/obs-backgroundremoval-lite-${tagName}-windows-x64.zip`
+      href=`https://github.com/kaito-tokyo/obs-backgroundremoval-lite/releases/download/${tagName}/backgroundremoval-lite-${tagName}-windows-x64.zip`
       >Windows</a
     >
     <a
-      href=`https://github.com/kaito-tokyo/obs-backgroundremoval-lite/releases/download/${tagName}/obs-backgroundremoval-lite-${tagName}-macos-universal.pkg`
+      href=`https://github.com/kaito-tokyo/obs-backgroundremoval-lite/releases/download/${tagName}/backgroundremoval-lite-${tagName}-macos-universal.pkg`
       >Mac</a
     >
     <a
-      href=`https://github.com/kaito-tokyo/obs-backgroundremoval-lite/releases/download/${tagName}/obs-backgroundremoval-lite-${tagName}-x86_64-linux-gnu.deb`
+      href=`https://github.com/kaito-tokyo/obs-backgroundremoval-lite/releases/download/${tagName}/backgroundremoval-lite-${tagName}-x86_64-linux-gnu.deb`
       >Ubuntu</a
     >
     <a

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -32,6 +32,10 @@ const tagName = release.tag_name;
       href="https://github.com/kaito-tokyo/obs-backgroundremoval-lite/tree/main/unsupported/arch#readme"
       >Arch Linux</a
     >
+    <a
+      href="https://github.com/kaito-tokyo/obs-backgroundremoval-lite/tree/main/unsupported/flatpak#readme"
+      >Flatpak</a
+    >
   </div>
 </Layout>
 


### PR DESCRIPTION
This pull request updates the download links on the main documentation page to reflect a change in the release asset naming convention. The asset filenames no longer include the `obs-` prefix, ensuring users are directed to the correct files for each platform.

**Documentation and link updates:**

* Updated all platform-specific download links in `docs/src/pages/index.astro` to use the new asset filenames without the `obs-` prefix.