### PR TITLE
chore: Update release metadata for 1.5.1

### DIFF
--- a/unsupported/arch/obs-backgroundremoval-lite/PKGBUILD
+++ b/unsupported/arch/obs-backgroundremoval-lite/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kaito Udagawa <umireon at kaito dot tokyo>
 pkgname=obs-backgroundremoval-lite
-pkgver=1.5.0
+pkgver=1.5.1
 pkgrel=1
 pkgdesc='Background Removal Lite for OBS Studio'
 arch=('x86_64')
@@ -10,7 +10,7 @@ depends=('obs-studio' 'fmt' 'ncnn')
 makedepends=('git' 'cmake' 'ninja')
 conflicts=("${pkgname}-git" "${pkgname}-git-debug")
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/kaito-tokyo/$pkgname/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('da5174833c98729d32acbc4662b3d3e6e5629e30c1f6bd3db9417bdfebf82d91')
+sha256sums=('91f7230303cfe4f0661f3e5bab15f54ce6999fb7989d1fc5d69fe22c321b0764')
 
 build() {
   cd "${pkgname}-${pkgver}"

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.BackgroundRemovalLite.metainfo.xml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.BackgroundRemovalLite.metainfo.xml
@@ -15,6 +15,19 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <releases>
+    <release version="1.5.1" date="2025-09-27">
+      <description>
+        <p>This release adds unofficial Flatpak build instructions, improves documentation, and fixes installer links.</p>
+        <ul>
+          <li>Flatpak build instructions added.</li>
+          <li>Documentation improvements.</li>
+          <li>Installer link corrections.</li>
+          <li>Project cleanup.</li>
+          <li>Arch Linux PKGBUILD & Flatpak metadata updates.</li>
+          <li>Release process & contributor docs enhanced.</li>
+        </ul>
+      </description>
+    </release>
     <release version="1.5.0" date="2025-09-27">
       <description>
         <p>This release adds support for Arch Linux packaging, includes a new Flatpak manifest, and brings several documentation and workflow improvements.</p>

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.BackgroundRemovalLite.yaml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.BackgroundRemovalLite.yaml
@@ -32,8 +32,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/kaito-tokyo/obs-backgroundremoval-lite.git
-        tag: 1.4.3
-        commit: '6628caf9ad6e741fe8dba5e6b0bd7250e79fbcd1'
+        tag: 1.5.1
+        commit: 'ea1003f39f1cda22545bef451334808f428b42f3'
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$


### PR DESCRIPTION
This PR updates the Arch Linux and Flatpak release metadata for version 1.5.1.