### PR TITLE
Update vcpkg-configuration.json

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "b1e15efef6758eaa0beb0a8732cfa66f6a68a81d",
+    "baseline": "2e6fcc44573d091af0321f99c89b212997a76f1f",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
This pull request updates the `vcpkg-configuration.json` file to use a newer baseline for the default vcpkg registry. This ensures that the project will use the latest available packages and bug fixes from the vcpkg repository.

- Updated the `baseline` field in `vcpkg-configuration.json` to reference commit `2e6fcc44573d091af0321f99c89b212997a76f1f` in the vcpkg registry, replacing the previous baseline.