### PR TITLE
Add VSCode config and update .gitignore, cleanup defines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Except for default project files
 !/.github
+!/.vscode
 !/build-aux
 !/cmake
 !/data

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,22 @@
+{
+    "configurations": [
+        {
+            "name": "Mac",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [
+                "PLUGIN_NAME=\"[plugin]\"",
+                "PLUGIN_VERSION=\"0.0.0\""
+            ],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c17",
+            "cppStandard": "c++14",
+            "intelliSenseMode": "macos-clang-arm64",
+            "macFrameworkPath": [
+                "${workspaceFolder}/.deps/obs-deps-qt6-2025-07-11-universal/lib"
+            ]
+        }
+    ],
+    "version": 4
+}

--- a/src/MainPluginContext.h
+++ b/src/MainPluginContext.h
@@ -20,13 +20,6 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include <obs.h>
 
-#ifndef PLUGIN_NAME
-#define PLUGIN_NAME "obs-backgroundremoval-lite"
-#endif
-#ifndef PLUGIN_VERSION
-#define PLUGIN_VERSION "0.0.0-alpha"
-#endif
-
 #ifdef __cplusplus
 
 #include <memory>


### PR DESCRIPTION
This pull request introduces a new VS Code configuration file for C/C++ development and removes hardcoded plugin name and version macros from the main plugin header. The changes help centralize configuration and reduce redundancy.

**Development environment configuration:**

* Added a `.vscode/c_cpp_properties.json` file to define include paths, compiler settings, and preprocessor defines for Mac development, improving consistency and ease of setup in VS Code.

**Code cleanup:**

* Removed hardcoded `PLUGIN_NAME` and `PLUGIN_VERSION` macro definitions from `src/MainPluginContext.h`, relying instead on external configuration (now provided by the VS Code settings).Added .vscode/c_cpp_properties.json for VSCode C++ configuration and updated .gitignore to allow the .vscode directory. Removed PLUGIN_NAME and PLUGIN_VERSION macro definitions from MainPluginContext.h, likely to centralize configuration.