### PR TITLE
Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Except for default project files
 !/.github
 !/.vscode
+/.vscode/settings.json
 !/build-aux
 !/cmake
 !/data

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,7 +3,13 @@
         {
             "name": "Mac",
             "includePath": [
-                "${workspaceFolder}/**"
+                "${workspaceFolder}/**",
+                "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1",
+                "/Applications/Xcode_16.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include",
+                "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include",
+                "/Applications/Xcode_16.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
+                "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks",
+                "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/SubFrameworks"
             ],
             "defines": [
                 "PLUGIN_NAME=\"[plugin]\"",

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -13,7 +13,8 @@
             ],
             "defines": [
                 "PLUGIN_NAME=\"[plugin]\"",
-                "PLUGIN_VERSION=\"0.0.0\""
+                "PLUGIN_VERSION=\"0.0.0\"",
+                "HAVE_BACKWARD"
             ],
             "compilerPath": "/usr/bin/clang",
             "cStandard": "c17",

--- a/src/BridgeUtils/ILogger.hpp
+++ b/src/BridgeUtils/ILogger.hpp
@@ -80,9 +80,9 @@ public:
 
 		error("--- Stack Trace ---\n{}", ss.str());
 	} catch (const std::exception &log_ex) {
-		blog(LOG_ERROR, "[LOGGER FATAL] Failed during exception logging: %s\n", log_ex.what());
+		error("[LOGGER FATAL] Failed during exception logging: %s\n", log_ex.what());
 	} catch (...) {
-		blog(LOG_ERROR, "[LOGGER FATAL] Unknown error during exception logging.\n");
+		error("[LOGGER FATAL] Unknown error during exception logging.");
 	}
 
 #else // !HAVE_BACKWARD
@@ -99,7 +99,7 @@ protected:
 
 	virtual void log(LogLevel level, std::string_view message) const noexcept = 0;
 
-	virtual std::string_view getPrefix() const noexcept { return ""; }
+	virtual const char *getPrefix() const noexcept = 0;
 
 private:
 	template<typename... Args>
@@ -110,9 +110,9 @@ private:
 		fmt::vformat_to(std::back_inserter(buffer), fmt, fmt::make_format_args(args...));
 		log(level, {buffer.data(), buffer.size()});
 	} catch (const std::exception &e) {
-		fprintf(stderr, "[LOGGER FATAL] Failed to format log message: %s\n", e.what());
+		fprintf(stderr, "%s: [LOGGER FATAL] Failed to format log message: %s\n", getPrefix(), e.what());
 	} catch (...) {
-		fprintf(stderr, "[LOGGER FATAL] An unknown error occurred while formatting log message.\n");
+		fprintf(stderr, "%s: [LOGGER FATAL] An unknown error occurred while formatting log message.\n", getPrefix());
 	}
 };
 

--- a/src/BridgeUtils/ILogger.hpp
+++ b/src/BridgeUtils/ILogger.hpp
@@ -28,6 +28,10 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 
 #include <fmt/format.h>
 
+#ifdef HAVE_BACKWARD
+#include <backward.hpp>
+#endif // HAVE_BACKWARD
+
 namespace KaitoTokyo {
 namespace BridgeUtils {
 
@@ -61,7 +65,34 @@ public:
 		formatAndLog(LogLevel::Error, fmt, std::forward<Args>(args)...);
 	}
 
-	virtual void logException(const std::exception &e, std::string_view context) const noexcept = 0;
+#ifdef HAVE_BACKWARD
+
+	virtual void logException(const std::exception &e, std::string_view context) const noexcept
+	try {
+		std::stringstream ss;
+		ss << context.data() << ": " << e.what() << "\n";
+
+		backward::StackTrace st;
+		st.load_here(32);
+
+		backward::Printer p;
+		p.print(st, ss);
+
+		error("--- Stack Trace ---\n{}", ss.str());
+	} catch (const std::exception &log_ex) {
+		blog(LOG_ERROR, "[LOGGER FATAL] Failed during exception logging: %s\n", log_ex.what());
+	} catch (...) {
+		blog(LOG_ERROR, "[LOGGER FATAL] Unknown error during exception logging.\n");
+	}
+
+#else // !HAVE_BACKWARD
+
+	virtual void logException(const std::exception &e, std::string_view context) const noexcept
+	{
+		error("{}: {}", context, e.what());
+	}
+
+#endif // HAVE_BACKWARD
 
 protected:
 	enum class LogLevel : std::int8_t { Debug, Info, Warn, Error };
@@ -73,17 +104,15 @@ protected:
 private:
 	template<typename... Args>
 	void formatAndLog(LogLevel level, fmt::format_string<Args...> fmt, Args &&...args) const noexcept
-	{
-		try {
-			fmt::memory_buffer buffer;
-			fmt::format_to(std::back_inserter(buffer), "{}", getPrefix());
-			fmt::vformat_to(std::back_inserter(buffer), fmt, fmt::make_format_args(args...));
-			log(level, {buffer.data(), buffer.size()});
-		} catch (const std::exception &e) {
-			fprintf(stderr, "[LOGGER FATAL] Failed to format log message: %s\n", e.what());
-		} catch (...) {
-			fprintf(stderr, "[LOGGER FATAL] An unknown error occurred while formatting log message.\n");
-		}
+	try {
+		fmt::memory_buffer buffer;
+		fmt::format_to(std::back_inserter(buffer), "{}", getPrefix());
+		fmt::vformat_to(std::back_inserter(buffer), fmt, fmt::make_format_args(args...));
+		log(level, {buffer.data(), buffer.size()});
+	} catch (const std::exception &e) {
+		fprintf(stderr, "[LOGGER FATAL] Failed to format log message: %s\n", e.what());
+	} catch (...) {
+		fprintf(stderr, "[LOGGER FATAL] An unknown error occurred while formatting log message.\n");
 	}
 };
 

--- a/src/BridgeUtils/ObsLogger.hpp
+++ b/src/BridgeUtils/ObsLogger.hpp
@@ -31,7 +31,7 @@ namespace BridgeUtils {
 
 class ObsLogger final : public ILogger {
 public:
-	ObsLogger(const std::string &_prefix) : prefix(_prefix) {}
+	ObsLogger(const char *_prefix) : prefix(_prefix) {}
 
 protected:
 	static constexpr size_t MAX_LOG_CHUNK_SIZE = 4000;
@@ -68,13 +68,11 @@ protected:
 		}
 	}
 
-	void logException(const std::exception &e, std::string_view context) const noexcept override;
-
 protected:
-	std::string_view getPrefix() const noexcept override { return prefix; }
+	const char *getPrefix() const noexcept override { return prefix; }
 
 private:
-	const std::string prefix;
+	const char *prefix;
 	mutable std::mutex mtx;
 };
 

--- a/src/BridgeUtils/ObsLogger.hpp
+++ b/src/BridgeUtils/ObsLogger.hpp
@@ -22,10 +22,6 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <sstream>
 #include <string_view>
 
-#ifdef HAVE_BACKWARD
-#include <backward.hpp>
-#endif // HAVE_BACKWARD
-
 #include <util/base.h>
 
 #include "ILogger.hpp"
@@ -81,37 +77,6 @@ private:
 	const std::string prefix;
 	mutable std::mutex mtx;
 };
-
-#ifdef HAVE_BACKWARD
-
-inline void ObsLogger::logException(const std::exception &e, std::string_view context) const noexcept
-{
-	try {
-		std::stringstream ss;
-		ss << context.data() << ": " << e.what() << "\n";
-
-		backward::StackTrace st;
-		st.load_here(32);
-
-		backward::Printer p;
-		p.print(st, ss);
-
-		error("--- Stack Trace ---\n{}", ss.str());
-	} catch (const std::exception &log_ex) {
-		blog(LOG_ERROR, "[LOGGER FATAL] Failed during exception logging: %s\n", log_ex.what());
-	} catch (...) {
-		blog(LOG_ERROR, "[LOGGER FATAL] Unknown error during exception logging.\n");
-	}
-}
-
-#else // !HAVE_BACKWARD
-
-inline void ObsLogger::logException(const std::exception &e, std::string_view context) const noexcept
-{
-	error("{}: {}", context, e.what());
-}
-
-#endif // HAVE_BACKWARD
 
 } // namespace BridgeUtils
 } // namespace KaitoTokyo


### PR DESCRIPTION
This pull request introduces several improvements and refactorings focused on logging infrastructure, color format handling, and code safety. The most significant changes include enhanced exception logging with optional stack traces, expanded support and safer handling of texture color formats, and interface adjustments for logger classes to improve consistency and robustness.

**Logging and Exception Handling Enhancements:**

* Added optional stack trace support to `ILogger`'s `logException` method using the `backward` library, controlled by the `HAVE_BACKWARD` define. This enables detailed error reporting when available, and falls back to simpler logging otherwise. (`src/BridgeUtils/ILogger.hpp`, `src/BridgeUtils/ObsLogger.hpp`, `.vscode/c_cpp_properties.json`) [[1]](diffhunk://#diff-232f72f7bd33d34562bf539d5307bb54ec285679c08ea3fb4ee63db41904b7b3R31-R34) [[2]](diffhunk://#diff-232f72f7bd33d34562bf539d5307bb54ec285679c08ea3fb4ee63db41904b7b3L64-R115) [[3]](diffhunk://#diff-7a7584aed12a14e413dbe796951225294c660dac5abb1b65b78e60d6c7953223L25-L28) [[4]](diffhunk://#diff-7a7584aed12a14e413dbe796951225294c660dac5abb1b65b78e60d6c7953223L75-L115) [[5]](diffhunk://#diff-7a7584aed12a14e413dbe796951225294c660dac5abb1b65b78e60d6c7953223L38-R34) [[6]](diffhunk://#diff-8f4e8cf66ff6479868eeeb084ef19fbb8bea6102cf86f8adec2180dcf38dc47dL6-R17)
* Refactored `ObsLogger` and `ILogger` to use `const char *` for prefixes instead of `std::string` or `std::string_view`, and made `getPrefix()` a pure virtual method returning `const char *` for consistency. (`src/BridgeUtils/ILogger.hpp`, `src/BridgeUtils/ObsLogger.hpp`) [[1]](diffhunk://#diff-232f72f7bd33d34562bf539d5307bb54ec285679c08ea3fb4ee63db41904b7b3L64-R115) [[2]](diffhunk://#diff-7a7584aed12a14e413dbe796951225294c660dac5abb1b65b78e60d6c7953223L38-R34) [[3]](diffhunk://#diff-7a7584aed12a14e413dbe796951225294c660dac5abb1b65b78e60d6c7953223L75-L115)

**Texture Format and Reader Improvements:**

* Expanded and improved the `getBytesPerPixel` function to handle more color formats, explicitly reject unsupported/compressed formats with exceptions, and ensure correct byte calculations. (`src/BridgeUtils/AsyncTextureReader.hpp`)
* The `AsyncTextureReader` constructor now requires an explicit color format argument, improving clarity and safety. (`src/BridgeUtils/AsyncTextureReader.hpp`)
* Removed the non-const `getBuffer()` accessor from `AsyncTextureReader` to enforce read-only buffer access and improve thread safety. (`src/BridgeUtils/AsyncTextureReader.hpp`)

**Code Cleanup and Safety:**

* Removed an unused `float16_to_double` function from `DebugWindow.cpp` and made pointer casts to buffer data `const` to improve code safety. (`src/DebugWindow.cpp`) [[1]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L70-L108) [[2]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L272-R233) [[3]](diffhunk://#diff-4b701534bd242aff61a610307ed5c6709af00a0fe27b6191f3e6f708b168c175L292-R253)

**Build Configuration:**

* Updated the VSCode C++ properties to include system and Xcode SDK headers, and added the `HAVE_BACKWARD` define for conditional compilation. (`.vscode/c_cpp_properties.json`)