### PR TITLE
Avx2 support

### DIFF
--- a/src/SelfieSegmenter/SelfieSegmenter.hpp
+++ b/src/SelfieSegmenter/SelfieSegmenter.hpp
@@ -171,15 +171,50 @@ bool isAVX2Available()
 
 inline void copyDataToMatAVX2(ncnn::Mat &inputMat, const std::uint8_t *bgra_data)
 {
-	float *r_channel = inputMat.channel(0);
-	float *g_channel = inputMat.channel(1);
-	float *b_channel = inputMat.channel(2);
+    float *r_channel = inputMat.channel(0);
+    float *g_channel = inputMat.channel(1);
+    float *b_channel = inputMat.channel(2);
 
-	for (int i = 0; i < PIXEL_COUNT; i++) {
-		b_channel[i] = (static_cast<float>(bgra_data[i * 4 + 0])) / 255.0f;
-		g_channel[i] = (static_cast<float>(bgra_data[i * 4 + 1])) / 255.0f;
-		r_channel[i] = (static_cast<float>(bgra_data[i * 4 + 2])) / 255.0f;
-	}
+    constexpr int PIXELS_PER_LOOP = 8;
+    constexpr int num_loops = SelfieSegmenterDetail::PIXEL_COUNT / PIXELS_PER_LOOP;
+
+    const __m256 v_inv_255 = _mm256_set1_ps(1.0f / 255.0f);
+
+    const __m256i shuffle_b_mask = _mm256_set_epi8(
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 28, 24, 20, 16,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 12,  8,  4,  0
+    );
+    const __m256i shuffle_g_mask = _mm256_set_epi8(
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 29, 25, 21, 17,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 13,  9,  5,  1
+    );
+    const __m256i shuffle_r_mask = _mm256_set_epi8(
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 30, 26, 22, 18,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 14, 10,  6,  2
+    );
+
+    for (int i = 0; i < num_loops; ++i) {
+        const int offset = i * PIXELS_PER_LOOP;
+        const int data_offset = offset * 4;
+
+        __m256i bgra_u8 = _mm256_loadu_si256((__m256i const*)(bgra_data + data_offset));
+
+        __m256i b_u8 = _mm256_shuffle_epi8(bgra_u8, shuffle_b_mask);
+        __m256i g_u8 = _mm256_shuffle_epi8(bgra_u8, shuffle_g_mask);
+        __m256i r_u8 = _mm256_shuffle_epi8(bgra_u8, shuffle_r_mask);
+        
+        __m256 b_ps = _mm256_cvtepi32_ps(_mm256_cvtepu8_epi32(_mm256_castsi256_si128(b_u8)));
+        __m256 g_ps = _mm256_cvtepi32_ps(_mm256_cvtepu8_epi32(_mm256_castsi256_si128(g_u8)));
+        __m256 r_ps = _mm256_cvtepi32_ps(_mm256_cvtepu8_epi32(_mm256_castsi256_si128(r_u8)));
+
+        b_ps = _mm256_mul_ps(b_ps, v_inv_255);
+        g_ps = _mm256_mul_ps(g_ps, v_inv_255);
+        r_ps = _mm256_mul_ps(r_ps, v_inv_255);
+
+        _mm256_storeu_ps(b_channel + offset, b_ps);
+        _mm256_storeu_ps(g_channel + offset, g_ps);
+        _mm256_storeu_ps(r_channel + offset, r_ps);
+    }
 }
 
 #else


### PR DESCRIPTION
This pull request adds AVX2 and NEON SIMD acceleration support to the `SelfieSegmenter` preprocessing pipeline, improving performance on modern x86_64 and ARM64 CPUs. The code now dynamically checks for AVX2 support at runtime and uses the fastest available method for converting BGRA image data to the required format for inference.

**SIMD Acceleration Support:**

* Added runtime detection of AVX2 support for x86_64 platforms and implemented an optimized `copyDataToMatAVX2` function using AVX2 intrinsics for faster BGRA-to-planar-float conversion. [[1]](diffhunk://#diff-81f5853caec6cc8e4f178a1afc7c60f6b17ebfe8751eb0eaee258ba383dce020R31-R45) [[2]](diffhunk://#diff-81f5853caec6cc8e4f178a1afc7c60f6b17ebfe8751eb0eaee258ba383dce020L132-R227)
* Improved NEON detection and usage for ARM64 platforms by introducing the `SELFIE_SEGMENTER_HAVE_NEON` macro and updating conditional compilation. [[1]](diffhunk://#diff-81f5853caec6cc8e4f178a1afc7c60f6b17ebfe8751eb0eaee258ba383dce020R31-R45) [[2]](diffhunk://#diff-81f5853caec6cc8e4f178a1afc7c60f6b17ebfe8751eb0eaee258ba383dce020L98-R110) [[3]](diffhunk://#diff-81f5853caec6cc8e4f178a1afc7c60f6b17ebfe8751eb0eaee258ba383dce020L132-R227)

**Preprocessing Pipeline Changes:**

* Updated the `SelfieSegmenter` class to check for AVX2 availability at construction and select the appropriate preprocessing method (AVX2, NEON, or naive) at runtime. [[1]](diffhunk://#diff-81f5853caec6cc8e4f178a1afc7c60f6b17ebfe8751eb0eaee258ba383dce020L146-R249) [[2]](diffhunk://#diff-81f5853caec6cc8e4f178a1afc7c60f6b17ebfe8751eb0eaee258ba383dce020L201-R305)

These changes collectively improve the performance and portability of the segmentation preprocessing across different CPU architectures.