### PR TITLE
Update SelfieSegmenter.cpp

### DIFF
--- a/src/SelfieSegmenter/SelfieSegmenter.cpp
+++ b/src/SelfieSegmenter/SelfieSegmenter.cpp
@@ -125,56 +125,38 @@ __attribute__((target("avx,avx2")))
 inline void
 copyDataToMatAVX2(ncnn::Mat &inputMat, const std::uint8_t *bgra_data)
 {
-	float *r_channel = inputMat.channel(0);
-	float *g_channel = inputMat.channel(1);
-	float *b_channel = inputMat.channel(2);
+    float *r_channel = inputMat.channel(0);
+    float *g_channel = inputMat.channel(1);
+    float *b_channel = inputMat.channel(2);
 
-	constexpr int PIXELS_PER_LOOP = 8;
-	const int num_loops = SelfieSegmenter::PIXEL_COUNT / PIXELS_PER_LOOP;
+    constexpr int PIXELS_PER_LOOP = 8;
+    const int num_loops = SelfieSegmenter::PIXEL_COUNT / PIXELS_PER_LOOP;
 
-	const __m256 v_inv_255 = _mm256_set1_ps(1.0f / 255.0f);
+    // 定数はループ外で定義
+    const __m256 v_inv_255 = _mm256_set1_ps(1.0f / 255.0f);
+    const __m256i mask_u8 = _mm256_set1_epi32(0x000000FF); // 各32-bit整数から下位8-bitを抽出するマスク
 
-	const __m128i shuffle_b_mask = _mm_set_epi8(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 12, 8, 4, 0);
-	const __m128i shuffle_g_mask = _mm_set_epi8(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 13, 9, 5, 1);
-	const __m128i shuffle_r_mask = _mm_set_epi8(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 14, 10, 6, 2);
+    for (int i = 0; i < num_loops; ++i) {
+        const int offset = i * PIXELS_PER_LOOP;
+        const int data_offset = offset * 4;
 
-	for (int i = 0; i < num_loops; ++i) {
-		const int offset = i * PIXELS_PER_LOOP;
-		const int data_offset = offset * 4;
+        __m256i bgra_u32 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(bgra_data + data_offset));
+        __m256i b_u32 = _mm256_and_si256(bgra_u32, mask_u8);
+        __m256i g_u32 = _mm256_and_si256(_mm256_srli_epi32(bgra_u32, 8), mask_u8);
+        __m256i r_u32 = _mm256_and_si256(_mm256_srli_epi32(bgra_u32, 16), mask_u8);
 
-		__m256i bgra_u8 = _mm256_loadu_si256((__m256i const *)(bgra_data + data_offset));
+        __m256 b_ps = _mm256_cvtepi32_ps(b_u32);
+        __m256 g_ps = _mm256_cvtepi32_ps(g_u32);
+        __m256 r_ps = _mm256_cvtepi32_ps(r_u32);
 
-		__m128i bgra_low = _mm256_castsi256_si128(bgra_u8);
-		__m128i bgra_high = _mm256_extracti128_si256(bgra_u8, 1);
+        b_ps = _mm256_mul_ps(b_ps, v_inv_255);
+        g_ps = _mm256_mul_ps(g_ps, v_inv_255);
+        r_ps = _mm256_mul_ps(r_ps, v_inv_255);
 
-		__m128i b_u8_low = _mm_shuffle_epi8(bgra_low, shuffle_b_mask);
-		__m128i g_u8_low = _mm_shuffle_epi8(bgra_low, shuffle_g_mask);
-		__m128i r_u8_low = _mm_shuffle_epi8(bgra_low, shuffle_r_mask);
-
-		__m128 b_ps_low = _mm_cvtepi32_ps(_mm_cvtepu8_epi32(b_u8_low));
-		__m128 g_ps_low = _mm_cvtepi32_ps(_mm_cvtepu8_epi32(g_u8_low));
-		__m128 r_ps_low = _mm_cvtepi32_ps(_mm_cvtepu8_epi32(r_u8_low));
-
-		__m128i b_u8_high = _mm_shuffle_epi8(bgra_high, shuffle_b_mask);
-		__m128i g_u8_high = _mm_shuffle_epi8(bgra_high, shuffle_g_mask);
-		__m128i r_u8_high = _mm_shuffle_epi8(bgra_high, shuffle_r_mask);
-
-		__m128 b_ps_high = _mm_cvtepi32_ps(_mm_cvtepu8_epi32(b_u8_high));
-		__m128 g_ps_high = _mm_cvtepi32_ps(_mm_cvtepu8_epi32(g_u8_high));
-		__m128 r_ps_high = _mm_cvtepi32_ps(_mm_cvtepu8_epi32(r_u8_high));
-
-		__m256 b_ps = _mm256_insertf128_ps(_mm256_castps128_ps256(b_ps_low), b_ps_high, 1);
-		__m256 g_ps = _mm256_insertf128_ps(_mm256_castps128_ps256(g_ps_low), g_ps_high, 1);
-		__m256 r_ps = _mm256_insertf128_ps(_mm256_castps128_ps256(r_ps_low), r_ps_high, 1);
-
-		b_ps = _mm256_mul_ps(b_ps, v_inv_255);
-		g_ps = _mm256_mul_ps(g_ps, v_inv_255);
-		r_ps = _mm256_mul_ps(r_ps, v_inv_255);
-
-		_mm256_storeu_ps(b_channel + offset, b_ps);
-		_mm256_storeu_ps(g_channel + offset, g_ps);
-		_mm256_storeu_ps(r_channel + offset, r_ps);
-	}
+        _mm256_storeu_ps(b_channel + offset, b_ps);
+        _mm256_storeu_ps(g_channel + offset, g_ps);
+        _mm256_storeu_ps(r_channel + offset, r_ps);
+    }
 }
 
 #else

--- a/src/SelfieSegmenter/SelfieSegmenter.cpp
+++ b/src/SelfieSegmenter/SelfieSegmenter.cpp
@@ -125,38 +125,38 @@ __attribute__((target("avx,avx2")))
 inline void
 copyDataToMatAVX2(ncnn::Mat &inputMat, const std::uint8_t *bgra_data)
 {
-    float *r_channel = inputMat.channel(0);
-    float *g_channel = inputMat.channel(1);
-    float *b_channel = inputMat.channel(2);
+	float *r_channel = inputMat.channel(0);
+	float *g_channel = inputMat.channel(1);
+	float *b_channel = inputMat.channel(2);
 
-    constexpr int PIXELS_PER_LOOP = 8;
-    const int num_loops = SelfieSegmenter::PIXEL_COUNT / PIXELS_PER_LOOP;
+	constexpr int PIXELS_PER_LOOP = 8;
+	const int num_loops = SelfieSegmenter::PIXEL_COUNT / PIXELS_PER_LOOP;
 
-    // 定数はループ外で定義
-    const __m256 v_inv_255 = _mm256_set1_ps(1.0f / 255.0f);
-    const __m256i mask_u8 = _mm256_set1_epi32(0x000000FF); // 各32-bit整数から下位8-bitを抽出するマスク
+	// 定数はループ外で定義
+	const __m256 v_inv_255 = _mm256_set1_ps(1.0f / 255.0f);
+	const __m256i mask_u8 = _mm256_set1_epi32(0x000000FF); // 各32-bit整数から下位8-bitを抽出するマスク
 
-    for (int i = 0; i < num_loops; ++i) {
-        const int offset = i * PIXELS_PER_LOOP;
-        const int data_offset = offset * 4;
+	for (int i = 0; i < num_loops; ++i) {
+		const int offset = i * PIXELS_PER_LOOP;
+		const int data_offset = offset * 4;
 
-        __m256i bgra_u32 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(bgra_data + data_offset));
-        __m256i b_u32 = _mm256_and_si256(bgra_u32, mask_u8);
-        __m256i g_u32 = _mm256_and_si256(_mm256_srli_epi32(bgra_u32, 8), mask_u8);
-        __m256i r_u32 = _mm256_and_si256(_mm256_srli_epi32(bgra_u32, 16), mask_u8);
+		__m256i bgra_u32 = _mm256_loadu_si256(reinterpret_cast<const __m256i *>(bgra_data + data_offset));
+		__m256i b_u32 = _mm256_and_si256(bgra_u32, mask_u8);
+		__m256i g_u32 = _mm256_and_si256(_mm256_srli_epi32(bgra_u32, 8), mask_u8);
+		__m256i r_u32 = _mm256_and_si256(_mm256_srli_epi32(bgra_u32, 16), mask_u8);
 
-        __m256 b_ps = _mm256_cvtepi32_ps(b_u32);
-        __m256 g_ps = _mm256_cvtepi32_ps(g_u32);
-        __m256 r_ps = _mm256_cvtepi32_ps(r_u32);
+		__m256 b_ps = _mm256_cvtepi32_ps(b_u32);
+		__m256 g_ps = _mm256_cvtepi32_ps(g_u32);
+		__m256 r_ps = _mm256_cvtepi32_ps(r_u32);
 
-        b_ps = _mm256_mul_ps(b_ps, v_inv_255);
-        g_ps = _mm256_mul_ps(g_ps, v_inv_255);
-        r_ps = _mm256_mul_ps(r_ps, v_inv_255);
+		b_ps = _mm256_mul_ps(b_ps, v_inv_255);
+		g_ps = _mm256_mul_ps(g_ps, v_inv_255);
+		r_ps = _mm256_mul_ps(r_ps, v_inv_255);
 
-        _mm256_storeu_ps(b_channel + offset, b_ps);
-        _mm256_storeu_ps(g_channel + offset, g_ps);
-        _mm256_storeu_ps(r_channel + offset, r_ps);
-    }
+		_mm256_storeu_ps(b_channel + offset, b_ps);
+		_mm256_storeu_ps(g_channel + offset, g_ps);
+		_mm256_storeu_ps(r_channel + offset, r_ps);
+	}
 }
 
 #else


### PR DESCRIPTION
This pull request refactors the pixel extraction logic in the `copyDataToMatAVX2` function within `SelfieSegmenter.cpp` to simplify and optimize the conversion of BGRA data to floating-point BGR channels using AVX2 intrinsics. The new approach eliminates the use of shuffle masks and multiple SSE/AVX conversions, resulting in cleaner and potentially more efficient code.

**Refactoring and optimization of pixel extraction:**

* Replaced the use of manual shuffle masks and multiple SSE/AVX instructions with a more straightforward masking and shifting approach to extract B, G, and R channels from BGRA data using AVX2 intrinsics. (`src/SelfieSegmenter/SelfieSegmenter.cpp`, [src/SelfieSegmenter/SelfieSegmenter.cppR135-R150](diffhunk://#diff-67b13eb7df5901f564f81c5d34120e05f04645d451579a8deb82f53710879febR135-R150))
* Removed the definition and use of `shuffle_b_mask`, `shuffle_g_mask`, and `shuffle_r_mask`, and replaced them with a single `mask_u8` and bitwise operations for channel extraction. (`src/SelfieSegmenter/SelfieSegmenter.cpp`, [src/SelfieSegmenter/SelfieSegmenter.cppR135-R150](diffhunk://#diff-67b13eb7df5901f564f81c5d34120e05f04645d451579a8deb82f53710879febR135-R150))
* Simplified the conversion of extracted channel data to floating-point by directly using `_mm256_cvtepi32_ps` on the masked and shifted values. (`src/SelfieSegmenter/SelfieSegmenter.cpp`, [src/SelfieSegmenter/SelfieSegmenter.cppR135-R150](diffhunk://#diff-67b13eb7df5901f564f81c5d34120e05f04645d451579a8deb82f53710879febR135-R150))