### PR TITLE
New logger

### DIFF
--- a/src/BridgeUtils/ILogger.hpp
+++ b/src/BridgeUtils/ILogger.hpp
@@ -40,8 +40,6 @@ public:
 	ILogger() noexcept = default;
 	virtual ~ILogger() noexcept = default;
 
-	ILogger(const ILogger &) = delete;
-	ILogger &operator=(const ILogger &) = delete;
 	ILogger(ILogger &&) = delete;
 	ILogger &operator=(ILogger &&) = delete;
 

--- a/src/Core/MainPluginContext.cpp
+++ b/src/Core/MainPluginContext.cpp
@@ -38,9 +38,10 @@ namespace KaitoTokyo {
 namespace BackgroundRemovalLite {
 
 MainPluginContext::MainPluginContext(obs_data_t *settings, obs_source_t *_source,
-				     std::shared_future<std::string> _latestVersionFuture)
+				     std::shared_future<std::string> _latestVersionFuture,
+				     const BridgeUtils::ILogger &_logger)
 	: source{_source},
-	  logger("[" PLUGIN_NAME "] "),
+	  logger(_logger),
 	  mainEffect(unique_obs_module_file("effects/main.effect"), logger),
 	  latestVersionFuture(_latestVersionFuture),
 	  selfieSegmenterTaskQueue(logger, 1)

--- a/src/Core/MainPluginContext.h
+++ b/src/Core/MainPluginContext.h
@@ -47,8 +47,8 @@ class RenderingContext;
 
 class MainPluginContext : public std::enable_shared_from_this<MainPluginContext> {
 private:
-	obs_source_t *const source = nullptr;
-	const BridgeUtils::ObsLogger logger;
+	obs_source_t *const source;
+	const BridgeUtils::ILogger &logger;
 	std::shared_future<std::string> latestVersionFuture;
 	const MainEffect mainEffect;
 	BridgeUtils::ThrottledTaskQueue selfieSegmenterTaskQueue;
@@ -63,7 +63,7 @@ private:
 
 public:
 	MainPluginContext(obs_data_t *settings, obs_source_t *source,
-			  std::shared_future<std::string> latestVersionFuture);
+			  std::shared_future<std::string> latestVersionFuture, const BridgeUtils::ILogger &logger);
 	void startup() noexcept;
 	void shutdown() noexcept;
 	~MainPluginContext() noexcept;

--- a/src/Core/MainPluginContext_c.cpp
+++ b/src/Core/MainPluginContext_c.cpp
@@ -32,6 +32,12 @@ namespace {
 
 std::shared_future<std::string> latestVersionFuture;
 
+inline const ILogger &logger()
+{
+	static const ObsLogger instance("[" PLUGIN_NAME "] ");
+	return instance;
+}
+
 } // namespace
 
 const char *main_plugin_context_get_name(void *type_data)
@@ -47,17 +53,17 @@ try {
 	self->startup();
 	return new std::shared_ptr<MainPluginContext>(self);
 } catch (const std::exception &e) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to create main plugin context: %s", e.what());
+	logger().error("Failed to create main plugin context: %s", e.what());
 	return nullptr;
 } catch (...) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to create main plugin context: unknown error");
+	logger().error("Failed to create main plugin context: unknown error");
 	return nullptr;
 }
 
 void main_plugin_context_destroy(void *data)
 try {
 	if (!data) {
-		blog(LOG_ERROR, "[" PLUGIN_NAME "] main_plugin_context_destroy called with null data");
+		logger().error("main_plugin_context_destroy called with null data");
 		return;
 	}
 
@@ -68,12 +74,12 @@ try {
 	GraphicsContextGuard guard;
 	GsUnique::drain();
 } catch (const std::exception &e) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to destroy main plugin context: %s", e.what());
+	logger().error("Failed to destroy main plugin context: %s", e.what());
 
 	GraphicsContextGuard guard;
 	GsUnique::drain();
 } catch (...) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to destroy main plugin context: unknown error");
+	logger().error("Failed to destroy main plugin context: unknown error");
 
 	GraphicsContextGuard guard;
 	GsUnique::drain();
@@ -82,7 +88,7 @@ try {
 std::uint32_t main_plugin_context_get_width(void *data)
 {
 	if (!data) {
-		blog(LOG_ERROR, "[" PLUGIN_NAME "] main_plugin_context_get_width called with null data");
+		logger().error("main_plugin_context_get_width called with null data");
 		return 0;
 	}
 
@@ -93,7 +99,7 @@ std::uint32_t main_plugin_context_get_width(void *data)
 std::uint32_t main_plugin_context_get_height(void *data)
 {
 	if (!data) {
-		blog(LOG_ERROR, "[" PLUGIN_NAME "] main_plugin_context_get_height called with null data");
+		logger().error("main_plugin_context_get_height called with null data");
 		return 0;
 	}
 
@@ -109,108 +115,108 @@ void main_plugin_context_get_defaults(obs_data_t *data)
 obs_properties_t *main_plugin_context_get_properties(void *data)
 try {
 	if (!data) {
-		blog(LOG_ERROR, "[" PLUGIN_NAME "] main_plugin_context_get_properties called with null data");
+		logger().error("main_plugin_context_get_properties called with null data");
 		return obs_properties_create();
 	}
 
 	auto self = static_cast<std::shared_ptr<MainPluginContext> *>(data);
 	return self->get()->getProperties();
 } catch (const std::exception &e) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to get properties: %s", e.what());
+	logger().error("Failed to get properties: %s", e.what());
 	return obs_properties_create();
 } catch (...) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to get properties: unknown error");
+	logger().error("Failed to get properties: unknown error");
 	return obs_properties_create();
 }
 
 void main_plugin_context_update(void *data, obs_data_t *settings)
 try {
 	if (!data) {
-		blog(LOG_ERROR, "[" PLUGIN_NAME "] main_plugin_context_update called with null data");
+		logger().error("main_plugin_context_update called with null data");
 		return;
 	}
 
 	auto self = static_cast<std::shared_ptr<MainPluginContext> *>(data);
 	self->get()->update(settings);
 } catch (const std::exception &e) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to update main plugin context: %s", e.what());
+	logger().error("Failed to update main plugin context: %s", e.what());
 } catch (...) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to update main plugin context: unknown error");
+	logger().error("Failed to update main plugin context: unknown error");
 }
 
 void main_plugin_context_activate(void *data)
 try {
 	if (!data) {
-		blog(LOG_ERROR, "[" PLUGIN_NAME "] main_plugin_context_activate called with null data");
+		logger().error("main_plugin_context_activate called with null data");
 		return;
 	}
 
 	auto self = static_cast<std::shared_ptr<MainPluginContext> *>(data);
 	self->get()->activate();
 } catch (const std::exception &e) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to activate main plugin context: %s", e.what());
+	logger().error("Failed to activate main plugin context: %s", e.what());
 } catch (...) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to activate main plugin context: unknown error");
+	logger().error("Failed to activate main plugin context: unknown error");
 }
 
 void main_plugin_context_deactivate(void *data)
 try {
 	if (!data) {
-		blog(LOG_ERROR, "[" PLUGIN_NAME "] main_plugin_context_deactivate called with null data");
+		logger().error("main_plugin_context_deactivate called with null data");
 		return;
 	}
 
 	auto self = static_cast<std::shared_ptr<MainPluginContext> *>(data);
 	self->get()->deactivate();
 } catch (const std::exception &e) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to deactivate main plugin context: %s", e.what());
+	logger().error("Failed to deactivate main plugin context: %s", e.what());
 } catch (...) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to deactivate main plugin context: unknown error");
+	logger().error("Failed to deactivate main plugin context: unknown error");
 }
 
 void main_plugin_context_show(void *data)
 try {
 	if (!data) {
-		blog(LOG_ERROR, "[" PLUGIN_NAME "] main_plugin_context_show called with null data");
+		logger().error("main_plugin_context_show called with null data");
 		return;
 	}
 
 	auto self = static_cast<std::shared_ptr<MainPluginContext> *>(data);
 	self->get()->show();
 } catch (const std::exception &e) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to show main plugin context: %s", e.what());
+	logger().error("Failed to show main plugin context: %s", e.what());
 } catch (...) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to show main plugin context: unknown error");
+	logger().error("Failed to show main plugin context: unknown error");
 }
 
 void main_plugin_context_hide(void *data)
 try {
 	if (!data) {
-		blog(LOG_ERROR, "[" PLUGIN_NAME "] main_plugin_context_hide called with null data");
+		logger().error("main_plugin_context_hide called with null data");
 		return;
 	}
 
 	auto self = static_cast<std::shared_ptr<MainPluginContext> *>(data);
 	self->get()->hide();
 } catch (const std::exception &e) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to hide main plugin context: %s", e.what());
+	logger().error("Failed to hide main plugin context: %s", e.what());
 } catch (...) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to hide main plugin context: unknown error");
+	logger().error("Failed to hide main plugin context: unknown error");
 }
 
 void main_plugin_context_video_tick(void *data, float seconds)
 try {
 	if (!data) {
-		blog(LOG_ERROR, "[" PLUGIN_NAME "] main_plugin_context_video_tick called with null data");
+		logger().error("main_plugin_context_video_tick called with null data");
 		return;
 	}
 
 	auto self = static_cast<std::shared_ptr<MainPluginContext> *>(data);
 	self->get()->videoTick(seconds);
 } catch (const std::exception &e) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to tick main plugin context: %s", e.what());
+	logger().error("Failed to tick main plugin context: %s", e.what());
 } catch (...) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to tick main plugin context: unknown error");
+	logger().error("Failed to tick main plugin context: unknown error");
 }
 
 void main_plugin_context_video_render(void *data, gs_effect_t *_unused)
@@ -218,7 +224,7 @@ try {
 	UNUSED_PARAMETER(_unused);
 
 	if (!data) {
-		blog(LOG_ERROR, "[" PLUGIN_NAME "] main_plugin_context_video_render called with null data");
+		logger().error("main_plugin_context_video_render called with null data");
 		return;
 	}
 
@@ -226,15 +232,15 @@ try {
 	self->get()->videoRender();
 	GsUnique::drain();
 } catch (const std::exception &e) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to render video in main plugin context: %s", e.what());
+	logger().error("Failed to render video in main plugin context: %s", e.what());
 } catch (...) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to render video in main plugin context: unknown error");
+	logger().error("Failed to render video in main plugin context: unknown error");
 }
 
 struct obs_source_frame *main_plugin_context_filter_video(void *data, struct obs_source_frame *frame)
 try {
 	if (!data) {
-		blog(LOG_ERROR, "[" PLUGIN_NAME "] main_plugin_context_filter_video called with null data");
+		logger().error("main_plugin_context_filter_video called with null data");
 		return frame;
 	}
 
@@ -242,10 +248,10 @@ try {
 	obs_source_frame *result = self->get()->filterVideo(frame);
 	return result;
 } catch (const std::exception &e) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to filter video in main plugin context: %s", e.what());
+	logger().error("Failed to filter video in main plugin context: %s", e.what());
 	return frame;
 } catch (...) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to filter video in main plugin context: unknown error");
+	logger().error("Failed to filter video in main plugin context: unknown error");
 	return frame;
 }
 
@@ -259,10 +265,10 @@ try {
 		}).share();
 	return true;
 } catch (const std::exception &e) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to load main plugin context: %s", e.what());
+	logger().error("Failed to load main plugin context: %s", e.what());
 	return false;
 } catch (...) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to load main plugin context: unknown error");
+	logger().error("Failed to load main plugin context: unknown error");
 	return false;
 }
 
@@ -271,7 +277,7 @@ try {
 	GraphicsContextGuard guard;
 	GsUnique::drain();
 } catch (const std::exception &e) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to unload main plugin context: %s", e.what());
+	logger().error("Failed to unload main plugin context: %s", e.what());
 } catch (...) {
-	blog(LOG_ERROR, "[" PLUGIN_NAME "] Failed to unload main plugin context: unknown error");
+	logger().error("Failed to unload main plugin context: unknown error");
 }

--- a/src/Core/MainPluginContext_c.cpp
+++ b/src/Core/MainPluginContext_c.cpp
@@ -49,7 +49,7 @@ const char *main_plugin_context_get_name(void *type_data)
 void *main_plugin_context_create(obs_data_t *settings, obs_source_t *source)
 try {
 	GraphicsContextGuard guard;
-	auto self = std::make_shared<MainPluginContext>(settings, source, latestVersionFuture);
+	auto self = std::make_shared<MainPluginContext>(settings, source, latestVersionFuture, logger());
 	self->startup();
 	return new std::shared_ptr<MainPluginContext>(self);
 } catch (const std::exception &e) {


### PR DESCRIPTION
This pull request refactors logging throughout the `MainPluginContext` code, replacing direct calls to the global `blog` function with usage of the `ILogger` interface. This change makes logging more modular and testable by injecting a logger dependency, and also updates the construction and usage of the logger in the main plugin context.

Key changes include:

**Logging Refactor:**

* Replaced all direct calls to the `blog` macro with calls to a provided `ILogger` interface, improving modularity and testability. All logging in `MainPluginContext_c.cpp` now goes through `logger().error(...)` instead of `blog(...)`. [[1]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L46-R66) [[2]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L71-R82) [[3]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L85-R91) [[4]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L96-R102) [[5]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L112-R254) [[6]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L262-R271) [[7]](diffhunk://#diff-e16b10f5c1f5c3e5c216873697101d0f9987253a6ad9920d97f1c6bdb56c1006L274-R282)

* Added a static function that returns a singleton logger instance (`logger()`) in `MainPluginContext_c.cpp`, and updated all relevant code to use this logger.

**Dependency Injection and Type Changes:**

* Updated the `MainPluginContext` constructor and member variables to accept and store a `const BridgeUtils::ILogger &` instead of constructing its own logger, enabling dependency injection for logging. [[1]](diffhunk://#diff-053c68a2145dddf96e5da0ca56ee213ce0d2f521b65788494bbdc8eeb570b872L41-R44) [[2]](diffhunk://#diff-3d15422a694d33b7267ddf3c4a970433df4ce699ae3c9173d0577711fb443fddL50-R51) [[3]](diffhunk://#diff-3d15422a694d33b7267ddf3c4a970433df4ce699ae3c9173d0577711fb443fddL66-R66)

**Other Minor Changes:**

* Removed deleted copy constructor and copy assignment operator from `ILogger`, possibly to allow more flexible usage or avoid unnecessary restrictions.