### PR TITLE
chore: update Arch/Flatpak manifests for 1.6.0

### DIFF
--- a/unsupported/arch/obs-backgroundremoval-lite/PKGBUILD
+++ b/unsupported/arch/obs-backgroundremoval-lite/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kaito Udagawa <umireon at kaito dot tokyo>
 pkgname=obs-backgroundremoval-lite
-pkgver=1.5.1
+pkgver=1.6.0
 pkgrel=1
 pkgdesc='Background Removal Lite for OBS Studio'
 arch=('x86_64')
@@ -10,7 +10,7 @@ depends=('obs-studio' 'fmt' 'ncnn')
 makedepends=('git' 'cmake' 'ninja')
 conflicts=("${pkgname}-git" "${pkgname}-git-debug")
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/kaito-tokyo/$pkgname/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('91f7230303cfe4f0661f3e5bab15f54ce6999fb7989d1fc5d69fe22c321b0764')
+sha256sums=('ad965ddd2889c756ea994e95a8983c593a2c916e019600274cc11448f4d3375a')
 
 build() {
   cd "${pkgname}-${pkgver}"

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.BackgroundRemovalLite.metainfo.xml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.BackgroundRemovalLite.metainfo.xml
@@ -15,6 +15,20 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <releases>
+    <release version="1.6.0" date="2025-09-29">
+      <description>
+        <p>🎉 <b>Release 1.6.0</b></p>
+        <ul>
+          <li>🚀 <b>Update Checker Returns!</b> Plugin now checks for new versions and notifies you in the filter UI. Localized status and clear messages.</li>
+          <li>💨 <b>Selfie Segmenter Performance Boost:</b> Major rewrite, SIMD acceleration (AVX2/NEON), new unit tests, and better maintainability.</li>
+          <li>🧩 <b>Project Structure Modernization:</b> Core logic reorganized, redundant files removed.</li>
+          <li>🛠️ <b>CMake & Build Improvements:</b> CMake detects/links curl & backward-cpp, AVX2 triplets, improved test infra.</li>
+          <li>🌍 <b>Localization & UI Enhancements:</b> Update checker info fully localized, clearer UI messages.</li>
+          <li>📚 <b>Documentation & Developer Guide Updates:</b> Release/dev guidelines clarified, Copilot/Gemini instructions improved.</li>
+        </ul>
+        <p>Thank you for using Background Removal Lite! Please report any issues or feedback.</p>
+      </description>
+    </release>
     <release version="1.5.1" date="2025-09-27">
       <description>
         <p>This release adds unofficial Flatpak build instructions, improves documentation, and fixes installer links.</p>

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.BackgroundRemovalLite.yaml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.BackgroundRemovalLite.yaml
@@ -32,8 +32,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/kaito-tokyo/obs-backgroundremoval-lite.git
-        tag: 1.5.1
-        commit: 'ea1003f39f1cda22545bef451334808f428b42f3'
+        tag: 1.6.0
+        commit: '6d7f6c7425f114064d365642ebecd48eb1e90917'
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$


### PR DESCRIPTION
This pull request updates the Background Removal Lite plugin for OBS Studio to version 1.6.0, incorporating the latest upstream release. The changes include updating the version and checksums in the Arch PKGBUILD, updating the Flatpak manifest to use the new release, and adding a detailed changelog for version 1.6.0. The new release brings significant improvements to update checking, performance, project structure, build system, localization, and documentation.

**Release and packaging updates:**

* Bump `obs-backgroundremoval-lite` version from 1.5.1 to 1.6.0 and update the corresponding SHA256 checksum in the PKGBUILD. [[1]](diffhunk://#diff-c6a1f42fe8180d62edd3e963e5edefabe0a4c6f89452c6430dd32a7aec85be58L3-R3) [[2]](diffhunk://#diff-c6a1f42fe8180d62edd3e963e5edefabe0a4c6f89452c6430dd32a7aec85be58L13-R13)
* Update Flatpak manifest to pull from the new 1.6.0 tag and commit.

**Changelog and documentation:**

* Add a new release entry for 1.6.0 in the Flatpak metainfo XML, summarizing major new features: update checker, performance improvements, project structure modernization, build and test enhancements, localization/UI improvements, and better documentation.