### PR TITLE
Remove unused difference with mask textures and logic

### DIFF
--- a/src/Core/RenderingContext.hpp
+++ b/src/Core/RenderingContext.hpp
@@ -70,13 +70,6 @@ public:
 
 	const BridgeUtils::unique_gs_texture_t r8SegmentationMask;
 
-	std::array<BridgeUtils::unique_gs_texture_t, 2> r32fSubOriginalGrayscales;
-	const BridgeUtils::unique_gs_texture_t r32fSubDifferenceWithMask;
-	const std::vector<BridgeUtils::unique_gs_texture_t> r32fSubDifferenceWithMaskReductionPyramid;
-
-private:
-	BridgeUtils::AsyncTextureReader readerReducedDifferenceWithMask;
-
 public:
 	const BridgeUtils::unique_gs_texture_t r8SubGFGuide;
 	const BridgeUtils::unique_gs_texture_t r8SubGFSource;

--- a/src/DebugWindow/DebugWindow.cpp
+++ b/src/DebugWindow/DebugWindow.cpp
@@ -39,9 +39,6 @@ constexpr char textureBgrxOriginalImage[] = "bgrxOriginalImage";
 constexpr char textureR32fOriginalGrayscale[] = "r32fOriginalGrayscale";
 constexpr char textureBgrxSegmenterInput[] = "bgrxSegmenterInput";
 constexpr char textureR8SegmentationMask[] = "r8SegmentationMask";
-constexpr char textureR32fSubOriginalGrayscales0[] = "r32fSubOriginalGrayscales[0]";
-constexpr char textureR32fSubOriginalGrayscales1[] = "r32fSubOriginalGrayscales[1]";
-constexpr char textureR32fSubDifferenceWithMask[] = "r32fSubDifferenceWithMask";
 constexpr char textureR8SubGFGuide[] = "r8SubGFGuide";
 constexpr char textureR8SubGFSource[] = "r8SubGFSource";
 constexpr char textureR32fSubGFMeanGuide[] = "r32fSubGFMeanGuide";
@@ -58,15 +55,9 @@ const std::vector<std::string> r32fTextures = {textureR32fOriginalGrayscale};
 const std::vector<std::string> bgrx256Textures = {textureBgrxSegmenterInput};
 const std::vector<std::string> r8MaskRoiTextures = {textureR8SegmentationMask};
 const std::vector<std::string> r8SubTextures = {textureR8SubGFGuide, textureR8SubGFSource};
-const std::vector<std::string> r32fSubTextures = {textureR32fSubOriginalGrayscales0,
-						  textureR32fSubOriginalGrayscales1,
-						  textureR32fSubDifferenceWithMask,
-						  textureR32fSubGFMeanGuide,
-						  textureR32fSubGFMeanSource,
-						  textureR16fSubGFMeanGuideSource,
-						  textureR32fSubGFMeanGuideSq,
-						  textureR32fSubGFA,
-						  textureR32fSubGFB};
+const std::vector<std::string> r32fSubTextures = {
+	textureR32fSubGFMeanGuide,   textureR32fSubGFMeanSource, textureR16fSubGFMeanGuideSource,
+	textureR32fSubGFMeanGuideSq, textureR32fSubGFA,          textureR32fSubGFB};
 
 } // namespace
 
@@ -85,9 +76,6 @@ DebugWindow::DebugWindow(std::weak_ptr<MainPluginContext> _weakMainPluginContext
 	previewTextureSelector->addItem(textureR32fOriginalGrayscale);
 	previewTextureSelector->addItem(textureBgrxSegmenterInput);
 	previewTextureSelector->addItem(textureR8SegmentationMask);
-	previewTextureSelector->addItem(textureR32fSubOriginalGrayscales0);
-	previewTextureSelector->addItem(textureR32fSubOriginalGrayscales1);
-	previewTextureSelector->addItem(textureR32fSubDifferenceWithMask);
 	previewTextureSelector->addItem(textureR8SubGFGuide);
 	previewTextureSelector->addItem(textureR8SubGFSource);
 	previewTextureSelector->addItem(textureR32fSubGFMeanGuide);
@@ -177,15 +165,6 @@ void DebugWindow::videoRender()
 		} else if (currentTexture == textureR8SegmentationMask) {
 			readerMaskRoiR8->sync();
 			readerMaskRoiR8->stage(renderingContext->r8SegmentationMask.get());
-		} else if (currentTexture == textureR32fSubOriginalGrayscales0) {
-			readerR32fSub->sync();
-			readerR32fSub->stage(renderingContext->r32fSubOriginalGrayscales[0].get());
-		} else if (currentTexture == textureR32fSubOriginalGrayscales1) {
-			readerR32fSub->sync();
-			readerR32fSub->stage(renderingContext->r32fSubOriginalGrayscales[1].get());
-		} else if (currentTexture == textureR32fSubDifferenceWithMask) {
-			readerR32fSub->sync();
-			readerR32fSub->stage(renderingContext->r32fSubDifferenceWithMask.get());
 		} else if (currentTexture == textureR8SubGFGuide) {
 			readerSubR8->sync();
 			readerSubR8->stage(renderingContext->r8SubGFGuide.get());


### PR DESCRIPTION
This pull request removes the calculation and handling of the "difference with mask" and related sub-original grayscale textures from the rendering pipeline. The main changes simplify the `RenderingContext` by eliminating unused or redundant intermediate textures and associated logic, and update the `DebugWindow` to reflect these removals.

**Rendering pipeline simplification:**

* Removed the creation, usage, and management of `r32fSubOriginalGrayscales`, `r32fSubDifferenceWithMask`, and the reduction pyramid textures from `RenderingContext`, including their initialization, rendering, and synchronization logic. [[1]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L93-L97) [[2]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L157-L158) [[3]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L184-L193) [[4]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L247) [[5]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L262) [[6]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L284) [[7]](diffhunk://#diff-d6f55194bdbeca9fe10b2b64c926de60f9c00508ed2c52dc9c5b33ec5c60cb77L73-L79)
* Removed the `calculateDifferenceWithMask()` function and its invocation from the rendering flow, as well as the associated asynchronous texture reader. [[1]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L184-L193) [[2]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L247) [[3]](diffhunk://#diff-d6f55194bdbeca9fe10b2b64c926de60f9c00508ed2c52dc9c5b33ec5c60cb77L73-L79)

**Debug window updates:**

* Removed all references to the eliminated textures (`r32fSubOriginalGrayscales[0]`, `r32fSubOriginalGrayscales[1]`, `r32fSubDifferenceWithMask`) from the debug texture lists, texture selector, and rendering logic in `DebugWindow.cpp`. [[1]](diffhunk://#diff-c34bc1ed5e618050723a4511eb81c121c88142467f171fb7e1948ae6f445c61bL42-L44) [[2]](diffhunk://#diff-c34bc1ed5e618050723a4511eb81c121c88142467f171fb7e1948ae6f445c61bL61-R60) [[3]](diffhunk://#diff-c34bc1ed5e618050723a4511eb81c121c88142467f171fb7e1948ae6f445c61bL88-L90) [[4]](diffhunk://#diff-c34bc1ed5e618050723a4511eb81c121c88142467f171fb7e1948ae6f445c61bL180-L188)Eliminated r32fSubOriginalGrayscales, r32fSubDifferenceWithMask, and related reduction pyramid from RenderingContext, as well as their usage in DebugWindow and rendering logic. This streamlines the code by removing unused resources and associated debug options.