### PR TITLE
Update MainEffect.hpp

### DIFF
--- a/src/Core/MainEffect.hpp
+++ b/src/Core/MainEffect.hpp
@@ -44,19 +44,6 @@ inline gs_eparam_t *getEffectParam(const BridgeUtils::unique_gs_effect_t &effect
 	return param;
 }
 
-inline gs_technique_t *getEffectTech(const BridgeUtils::unique_gs_effect_t &effect, const char *name,
-				     const BridgeUtils::ILogger &logger)
-{
-	gs_technique_t *tech = gs_effect_get_technique(effect.get(), name);
-
-	if (!tech) {
-		logger.error("Effect technique {} not found", name);
-		throw std::runtime_error("Effect technique not found");
-	}
-
-	return tech;
-}
-
 } // namespace main_effect_detail
 
 struct TransformStateGuard {
@@ -110,23 +97,6 @@ public:
 	gs_eparam_t *const floatLowerBound = nullptr;
 	gs_eparam_t *const floatUpperBound = nullptr;
 
-	gs_technique_t *const techDraw = nullptr;
-	gs_technique_t *const techDrawWithMask = nullptr;
-	gs_technique_t *const techDrawWithRefinedMask = nullptr;
-	gs_technique_t *const techResampleByNearestR8 = nullptr;
-	gs_technique_t *const techConvertToGrayscale = nullptr;
-	gs_technique_t *const techCalculateDifferenceWithMask = nullptr;
-	gs_technique_t *const techReduce = nullptr;
-	gs_technique_t *const techHorizontalBoxFilterR8KS17 = nullptr;
-	gs_technique_t *const techHorizontalBoxFilterWithMulR8KS17 = nullptr;
-	gs_technique_t *const techHorizontalBoxFilterWithSqR8KS17 = nullptr;
-	gs_technique_t *const techVerticalBoxFilterR8KS17 = nullptr;
-	gs_technique_t *const techMultiplyR8 = nullptr;
-	gs_technique_t *const techSquareR8 = nullptr;
-	gs_technique_t *const techCalculateGuidedFilterA = nullptr;
-	gs_technique_t *const techCalculateGuidedFilterB = nullptr;
-	gs_technique_t *const techFinalizeGuidedFilter = nullptr;
-
 	MainEffect(const BridgeUtils::unique_bfree_char_t &effectPath, const BridgeUtils::ILogger &logger)
 		: effect(BridgeUtils::make_unique_gs_effect_from_file(effectPath)),
 		  textureImage(main_effect_detail::getEffectParam(effect, "image", logger)),
@@ -138,28 +108,7 @@ public:
 		  floatEps(main_effect_detail::getEffectParam(effect, "eps", logger)),
 		  floatGamma(main_effect_detail::getEffectParam(effect, "gamma", logger)),
 		  floatLowerBound(main_effect_detail::getEffectParam(effect, "lowerBound", logger)),
-		  floatUpperBound(main_effect_detail::getEffectParam(effect, "upperBound", logger)),
-		  techDraw(main_effect_detail::getEffectTech(effect, "Draw", logger)),
-		  techDrawWithMask(main_effect_detail::getEffectTech(effect, "DrawWithMask", logger)),
-		  techDrawWithRefinedMask(main_effect_detail::getEffectTech(effect, "DrawWithRefinedMask", logger)),
-		  techResampleByNearestR8(main_effect_detail::getEffectTech(effect, "ResampleByNearestR8", logger)),
-		  techConvertToGrayscale(main_effect_detail::getEffectTech(effect, "ConvertToGrayscale", logger)),
-		  techReduce(main_effect_detail::getEffectTech(effect, "Reduce", logger)),
-		  techCalculateDifferenceWithMask(
-			  main_effect_detail::getEffectTech(effect, "CalculateDifferenceWithMask", logger)),
-		  techHorizontalBoxFilterR8KS17(
-			  main_effect_detail::getEffectTech(effect, "HorizontalBoxFilterR8KS17", logger)),
-		  techHorizontalBoxFilterWithMulR8KS17(
-			  main_effect_detail::getEffectTech(effect, "HorizontalBoxFilterWithMulR8KS17", logger)),
-		  techHorizontalBoxFilterWithSqR8KS17(
-			  main_effect_detail::getEffectTech(effect, "HorizontalBoxFilterWithSqR8KS17", logger)),
-		  techVerticalBoxFilterR8KS17(
-			  main_effect_detail::getEffectTech(effect, "VerticalBoxFilterR8KS17", logger)),
-		  techCalculateGuidedFilterA(
-			  main_effect_detail::getEffectTech(effect, "CalculateGuidedFilterA", logger)),
-		  techCalculateGuidedFilterB(
-			  main_effect_detail::getEffectTech(effect, "CalculateGuidedFilterB", logger)),
-		  techFinalizeGuidedFilter(main_effect_detail::getEffectTech(effect, "FinalizeGuidedFilter", logger))
+		  floatUpperBound(main_effect_detail::getEffectParam(effect, "upperBound", logger))
 	{
 	}
 
@@ -170,56 +119,36 @@ public:
 
 	void draw(std::uint32_t width, std::uint32_t height, gs_texture_t *sourceTexture) const noexcept
 	{
-		gs_technique_t *tech = techDraw;
-		std::size_t passes = gs_technique_begin(tech);
-		for (std::size_t i = 0; i < passes; i++) {
-			if (gs_technique_begin_pass(tech, i)) {
-				gs_effect_set_texture(textureImage, sourceTexture);
-
-				gs_draw_sprite(nullptr, 0, width, height);
-				gs_technique_end_pass(tech);
-			}
+		while (gs_effect_loop(effect.get(), "Draw")) {
+			gs_effect_set_texture(textureImage, sourceTexture);
+			gs_draw_sprite(nullptr, 0, width, height);
 		}
-		gs_technique_end(tech);
 	}
 
 	void drawWithMask(std::uint32_t width, std::uint32_t height, gs_texture_t *sourceTexture,
 			  gs_texture_t *maskTexture) const noexcept
 	{
-		gs_technique_t *tech = techDrawWithMask;
-		std::size_t passes = gs_technique_begin(tech);
-		for (std::size_t i = 0; i < passes; i++) {
-			if (gs_technique_begin_pass(tech, i)) {
-				gs_effect_set_texture(textureImage, sourceTexture);
-				gs_effect_set_texture(textureImage1, maskTexture);
-
-				gs_draw_sprite(nullptr, 0, width, height);
-				gs_technique_end_pass(tech);
-			}
+		while (gs_effect_loop(effect.get(), "DrawWithMask")) {
+			gs_effect_set_texture(textureImage, sourceTexture);
+			gs_effect_set_texture(textureImage1, maskTexture);
+			gs_draw_sprite(nullptr, 0, width, height);
 		}
-		gs_technique_end(tech);
 	}
 
 	void drawWithRefinedMask(std::uint32_t width, std::uint32_t height, gs_texture_t *sourceTexture,
 				 gs_texture_t *maskTexture, double gamma, double lowerBound,
 				 double upperBound) const noexcept
 	{
-		gs_technique_t *tech = techDrawWithRefinedMask;
-		std::size_t passes = gs_technique_begin(tech);
-		for (std::size_t i = 0; i < passes; i++) {
-			if (gs_technique_begin_pass(tech, i)) {
-				gs_effect_set_texture(textureImage, sourceTexture);
-				gs_effect_set_texture(textureImage1, maskTexture);
+		while (gs_effect_loop(effect.get(), "DrawWithRefinedMask")) {
+			gs_effect_set_texture(textureImage, sourceTexture);
+			gs_effect_set_texture(textureImage1, maskTexture);
 
-				gs_effect_set_float(floatGamma, static_cast<float>(gamma));
-				gs_effect_set_float(floatLowerBound, static_cast<float>(lowerBound));
-				gs_effect_set_float(floatUpperBound, static_cast<float>(upperBound));
+			gs_effect_set_float(floatGamma, static_cast<float>(gamma));
+			gs_effect_set_float(floatLowerBound, static_cast<float>(lowerBound));
+			gs_effect_set_float(floatUpperBound, static_cast<float>(upperBound));
 
-				gs_draw_sprite(nullptr, 0, width, height);
-				gs_technique_end_pass(tech);
-			}
+			gs_draw_sprite(nullptr, 0, width, height);
 		}
-		gs_technique_end(tech);
 	}
 
 	void resampleByNearestR8(std::uint32_t targetWidth, std::uint32_t targetHeight, gs_texture_t *targetTexture,
@@ -234,17 +163,10 @@ public:
 		gs_matrix_identity();
 
 		gs_set_render_target_with_color_space(targetTexture, nullptr, GS_CS_SRGB);
-		gs_technique_t *tech = techResampleByNearestR8;
-		std::size_t passes = gs_technique_begin(tech);
-		for (std::size_t i = 0; i < passes; i++) {
-			if (gs_technique_begin_pass(tech, i)) {
-				gs_effect_set_texture(textureImage, sourceTexture);
-
-				gs_draw_sprite(nullptr, 0, targetWidth, targetHeight);
-				gs_technique_end_pass(tech);
-			}
+		while (gs_effect_loop(effect.get(), "ResampleByNearestR8")) {
+			gs_effect_set_texture(textureImage, sourceTexture);
+			gs_draw_sprite(nullptr, 0, targetWidth, targetHeight);
 		}
-		gs_technique_end(tech);
 	}
 
 	void convertToGrayscale(std::uint32_t width, std::uint32_t height, gs_texture_t *targetTexture,
@@ -258,17 +180,11 @@ public:
 		gs_matrix_identity();
 
 		gs_set_render_target_with_color_space(targetTexture, nullptr, GS_CS_SRGB);
-		gs_technique_t *tech = techConvertToGrayscale;
-		std::size_t passes = gs_technique_begin(tech);
-		for (std::size_t i = 0; i < passes; i++) {
-			if (gs_technique_begin_pass(tech, i)) {
-				gs_effect_set_texture(textureImage, sourceTexture);
+		while (gs_effect_loop(effect.get(), "ConvertToGrayscale")) {
+			gs_effect_set_texture(textureImage, sourceTexture);
 
-				gs_draw_sprite(nullptr, 0, width, height);
-				gs_technique_end_pass(tech);
-			}
+			gs_draw_sprite(nullptr, 0, width, height);
 		}
-		gs_technique_end(tech);
 	}
 
 	void calculateDifferenceWithMask(std::uint32_t width, std::uint32_t height,
@@ -285,55 +201,12 @@ public:
 		gs_matrix_identity();
 
 		gs_set_render_target_with_color_space(targetTexture.get(), nullptr, GS_CS_SRGB);
-		gs_technique_t *tech = techCalculateDifferenceWithMask;
-		std::size_t passes = gs_technique_begin(tech);
-		for (std::size_t i = 0; i < passes; i++) {
-			if (gs_technique_begin_pass(tech, i)) {
-				gs_effect_set_texture(textureImage, currentGrayscaleTexture.get());
-				gs_effect_set_texture(textureImage1, lastGrayscaleTexture.get());
-				gs_effect_set_texture(textureImage2, segmentationMaskTexture.get());
+		while (gs_effect_loop(effect.get(), "CalculateDifferenceWithMask")) {
+			gs_effect_set_texture(textureImage, currentGrayscaleTexture.get());
+			gs_effect_set_texture(textureImage1, lastGrayscaleTexture.get());
+			gs_effect_set_texture(textureImage2, segmentationMaskTexture.get());
 
-				gs_draw_sprite(nullptr, 0, width, height);
-				gs_technique_end_pass(tech);
-			}
-		}
-		gs_technique_end(tech);
-	}
-
-	void reduce(const std::vector<BridgeUtils::unique_gs_texture_t> &reductionPyramidTextures,
-		    const BridgeUtils::unique_gs_texture_t &sourceTexture) const noexcept
-	{
-		RenderTargetGuard renderTargetGuard;
-		TransformStateGuard transformStateGuard;
-
-		gs_technique_t *tech = techReduce;
-
-		gs_texture_t *currentSource = sourceTexture.get();
-
-		for (const auto &currentTargetTexture : reductionPyramidTextures) {
-			gs_texture_t *currentTarget = currentTargetTexture.get();
-			const std::uint32_t targetWidth = gs_texture_get_width(currentTarget);
-			const std::uint32_t targetHeight = gs_texture_get_height(currentTarget);
-
-			gs_set_render_target_with_color_space(currentTarget, nullptr, GS_CS_SRGB);
-			gs_set_viewport(0, 0, targetWidth, targetHeight);
-			gs_ortho(0.0f, static_cast<float>(targetWidth), 0.0f, static_cast<float>(targetHeight), -100.0f,
-				 100.0f);
-			gs_matrix_identity();
-
-			std::size_t passes = gs_technique_begin(tech);
-			for (std::size_t i = 0; i < passes; i++) {
-				if (gs_technique_begin_pass(tech, i)) {
-					gs_effect_set_texture(textureImage, currentSource);
-
-					gs_draw_sprite(nullptr, 0, targetWidth, targetHeight);
-
-					gs_technique_end_pass(tech);
-				}
-			}
-			gs_technique_end(tech);
-
-			currentSource = currentTarget;
+			gs_draw_sprite(nullptr, 0, width, height);
 		}
 	}
 
@@ -351,32 +224,18 @@ public:
 		const float texelHeight = 1.0f / static_cast<float>(height);
 
 		gs_set_render_target_with_color_space(temporaryTexture1, nullptr, GS_CS_SRGB);
-		std::size_t passesHorizontal = gs_technique_begin(techHorizontalBoxFilterR8KS17);
-		for (std::size_t i = 0; i < passesHorizontal; i++) {
-			if (gs_technique_begin_pass(techHorizontalBoxFilterR8KS17, i)) {
-				gs_effect_set_texture(textureImage, sourceTexture);
-
-				gs_effect_set_float(floatTexelWidth, texelWidth);
-
-				gs_draw_sprite(nullptr, 0, width, height);
-				gs_technique_end_pass(techHorizontalBoxFilterR8KS17);
-			}
+		while (gs_effect_loop(effect.get(), "HorizontalBoxFilterR8KS17")) {
+			gs_effect_set_texture(textureImage, sourceTexture);
+			gs_effect_set_float(floatTexelWidth, texelWidth);
+			gs_draw_sprite(nullptr, 0, width, height);
 		}
-		gs_technique_end(techHorizontalBoxFilterR8KS17);
 
 		gs_set_render_target_with_color_space(targetTexture, nullptr, GS_CS_SRGB);
-		std::size_t passesVertical = gs_technique_begin(techVerticalBoxFilterR8KS17);
-		for (std::size_t i = 0; i < passesVertical; i++) {
-			if (gs_technique_begin_pass(techVerticalBoxFilterR8KS17, i)) {
-				gs_effect_set_texture(textureImage, temporaryTexture1);
-
-				gs_effect_set_float(floatTexelHeight, texelHeight);
-
-				gs_draw_sprite(nullptr, 0, width, height);
-				gs_technique_end_pass(techVerticalBoxFilterR8KS17);
-			}
+		while (gs_effect_loop(effect.get(), "VerticalBoxFilterR8KS17")) {
+			gs_effect_set_texture(textureImage, temporaryTexture1);
+			gs_effect_set_float(floatTexelHeight, texelHeight);
+			gs_draw_sprite(nullptr, 0, width, height);
 		}
-		gs_technique_end(techVerticalBoxFilterR8KS17);
 	}
 
 	void applyBoxFilterWithMulR8KS17(std::uint32_t width, std::uint32_t height, gs_texture_t *targetTexture,
@@ -394,33 +253,21 @@ public:
 		const float texelHeight = 1.0f / static_cast<float>(height);
 
 		gs_set_render_target_with_color_space(temporaryTexture1, nullptr, GS_CS_SRGB);
-		std::size_t passesHorizontal = gs_technique_begin(techHorizontalBoxFilterWithMulR8KS17);
-		for (std::size_t i = 0; i < passesHorizontal; i++) {
-			if (gs_technique_begin_pass(techHorizontalBoxFilterWithMulR8KS17, i)) {
-				gs_effect_set_texture(textureImage, source1Texture);
-				gs_effect_set_texture(textureImage1, source2Texture);
+		while (gs_effect_loop(effect.get(), "HorizontalBoxFilterWithMulR8KS17")) {
+			gs_effect_set_texture(textureImage, source1Texture);
+			gs_effect_set_texture(textureImage1, source2Texture);
 
-				gs_effect_set_float(floatTexelWidth, texelWidth);
+			gs_effect_set_float(floatTexelWidth, texelWidth);
 
-				gs_draw_sprite(nullptr, 0, width, height);
-				gs_technique_end_pass(techHorizontalBoxFilterWithMulR8KS17);
-			}
+			gs_draw_sprite(nullptr, 0, width, height);
 		}
-		gs_technique_end(techHorizontalBoxFilterWithMulR8KS17);
 
 		gs_set_render_target_with_color_space(targetTexture, nullptr, GS_CS_SRGB);
-		std::size_t passesVertical = gs_technique_begin(techVerticalBoxFilterR8KS17);
-		for (std::size_t i = 0; i < passesVertical; i++) {
-			if (gs_technique_begin_pass(techVerticalBoxFilterR8KS17, i)) {
-				gs_effect_set_texture(textureImage, temporaryTexture1);
-
-				gs_effect_set_float(floatTexelHeight, texelHeight);
-
-				gs_draw_sprite(nullptr, 0, width, height);
-				gs_technique_end_pass(techVerticalBoxFilterR8KS17);
-			}
+		while (gs_effect_loop(effect.get(), "VerticalBoxFilterR8KS17")) {
+			gs_effect_set_texture(textureImage, temporaryTexture1);
+			gs_effect_set_float(floatTexelHeight, texelHeight);
+			gs_draw_sprite(nullptr, 0, width, height);
 		}
-		gs_technique_end(techVerticalBoxFilterR8KS17);
 	}
 
 	void applyBoxFilterWithSqR8KS17(std::uint32_t width, std::uint32_t height, gs_texture_t *targetTexture,
@@ -437,32 +284,20 @@ public:
 		const float texelHeight = 1.0f / static_cast<float>(height);
 
 		gs_set_render_target_with_color_space(temporaryTexture1, nullptr, GS_CS_SRGB);
-		std::size_t passesHorizontal = gs_technique_begin(techHorizontalBoxFilterWithSqR8KS17);
-		for (std::size_t i = 0; i < passesHorizontal; i++) {
-			if (gs_technique_begin_pass(techHorizontalBoxFilterWithSqR8KS17, i)) {
-				gs_effect_set_texture(textureImage, sourceTexture);
-
-				gs_effect_set_float(floatTexelWidth, texelWidth);
-
-				gs_draw_sprite(nullptr, 0, width, height);
-				gs_technique_end_pass(techHorizontalBoxFilterWithSqR8KS17);
-			}
+		while (gs_effect_loop(effect.get(), "HorizontalBoxFilterWithSqR8KS17")) {
+			gs_effect_set_texture(textureImage, sourceTexture);
+			gs_effect_set_float(floatTexelWidth, texelWidth);
+			gs_draw_sprite(nullptr, 0, width, height);
 		}
-		gs_technique_end(techHorizontalBoxFilterWithSqR8KS17);
 
 		gs_set_render_target_with_color_space(targetTexture, nullptr, GS_CS_SRGB);
-		std::size_t passesVertical = gs_technique_begin(techVerticalBoxFilterR8KS17);
-		for (std::size_t i = 0; i < passesVertical; i++) {
-			if (gs_technique_begin_pass(techVerticalBoxFilterR8KS17, i)) {
-				gs_effect_set_texture(textureImage, temporaryTexture1);
+		while (gs_effect_loop(effect.get(), "VerticalBoxFilterR8KS17")) {
+			gs_effect_set_texture(textureImage, temporaryTexture1);
 
-				gs_effect_set_float(floatTexelHeight, texelHeight);
+			gs_effect_set_float(floatTexelHeight, texelHeight);
 
-				gs_draw_sprite(nullptr, 0, width, height);
-				gs_technique_end_pass(techVerticalBoxFilterR8KS17);
-			}
+			gs_draw_sprite(nullptr, 0, width, height);
 		}
-		gs_technique_end(techVerticalBoxFilterR8KS17);
 	}
 
 	void calculateGuidedFilterAAndB(std::uint32_t width, std::uint32_t height, gs_texture_t *targetATexture,
@@ -479,34 +314,24 @@ public:
 		gs_matrix_identity();
 
 		gs_set_render_target_with_color_space(targetATexture, nullptr, GS_CS_SRGB);
-		std::size_t passesA = gs_technique_begin(techCalculateGuidedFilterA);
-		for (std::size_t i = 0; i < passesA; i++) {
-			if (gs_technique_begin_pass(techCalculateGuidedFilterA, i)) {
-				gs_effect_set_texture(textureImage, sourceMeanGuideSqTexture);
-				gs_effect_set_texture(textureImage1, sourceMeanGuideTexture);
-				gs_effect_set_texture(textureImage2, sourceMeanGuideSourceTexture);
-				gs_effect_set_texture(textureImage3, sourceMeanSourceTexture);
-				gs_effect_set_float(floatEps, eps);
+		while (gs_effect_loop(effect.get(), "VerticalBoxFilterR8KS17")) {
+			gs_effect_set_texture(textureImage, sourceMeanGuideSqTexture);
+			gs_effect_set_texture(textureImage1, sourceMeanGuideTexture);
+			gs_effect_set_texture(textureImage2, sourceMeanGuideSourceTexture);
+			gs_effect_set_texture(textureImage3, sourceMeanSourceTexture);
+			gs_effect_set_float(floatEps, eps);
 
-				gs_draw_sprite(nullptr, 0, width, height);
-				gs_technique_end_pass(techCalculateGuidedFilterA);
-			}
+			gs_draw_sprite(nullptr, 0, width, height);
 		}
-		gs_technique_end(techCalculateGuidedFilterA);
 
 		gs_set_render_target_with_color_space(targetBTexture, nullptr, GS_CS_SRGB);
-		std::size_t passesB = gs_technique_begin(techCalculateGuidedFilterB);
-		for (std::size_t i = 0; i < passesB; i++) {
-			if (gs_technique_begin_pass(techCalculateGuidedFilterB, i)) {
-				gs_effect_set_texture(textureImage, targetATexture);
-				gs_effect_set_texture(textureImage1, sourceMeanSourceTexture);
-				gs_effect_set_texture(textureImage2, sourceMeanGuideTexture);
+		while (gs_effect_loop(effect.get(), "VerticalBoxFilterR8KS17")) {
+			gs_effect_set_texture(textureImage, targetATexture);
+			gs_effect_set_texture(textureImage1, sourceMeanSourceTexture);
+			gs_effect_set_texture(textureImage2, sourceMeanGuideTexture);
 
-				gs_draw_sprite(nullptr, 0, width, height);
-				gs_technique_end_pass(techCalculateGuidedFilterB);
-			}
+			gs_draw_sprite(nullptr, 0, width, height);
 		}
-		gs_technique_end(techCalculateGuidedFilterB);
 	}
 
 	void finalizeGuidedFilter(std::uint32_t width, std::uint32_t height, gs_texture_t *targetTexture,
@@ -520,20 +345,14 @@ public:
 		gs_ortho(0.0f, static_cast<float>(width), 0.0f, static_cast<float>(height), -100.0f, 100.0f);
 		gs_matrix_identity();
 
-		gs_technique_t *tech = techFinalizeGuidedFilter;
 		gs_set_render_target_with_color_space(targetTexture, nullptr, GS_CS_SRGB);
-		std::size_t passes = gs_technique_begin(tech);
-		for (std::size_t i = 0; i < passes; i++) {
-			if (gs_technique_begin_pass(tech, i)) {
-				gs_effect_set_texture(textureImage, sourceGuideTexture);
-				gs_effect_set_texture(textureImage1, sourceATexture);
-				gs_effect_set_texture(textureImage2, sourceBTexture);
+		while (gs_effect_loop(effect.get(), "FinalizeGuidedFilter")) {
+			gs_effect_set_texture(textureImage, sourceGuideTexture);
+			gs_effect_set_texture(textureImage1, sourceATexture);
+			gs_effect_set_texture(textureImage2, sourceBTexture);
 
-				gs_draw_sprite(nullptr, 0, width, height);
-				gs_technique_end_pass(tech);
-			}
+			gs_draw_sprite(nullptr, 0, width, height);
 		}
-		gs_technique_end(tech);
 	}
 };
 


### PR DESCRIPTION
This pull request refactors the `MainEffect` class to simplify effect technique handling and streamline rendering logic. The main changes involve removing explicit technique member variables and related helper functions, and updating rendering methods to use a more concise effect loop pattern. This results in cleaner, less error-prone code and reduces boilerplate.

**Refactoring of effect technique management:**

* Removed all `gs_technique_t*` member variables from the `MainEffect` class, eliminating the need to store explicit pointers for each effect technique.
* Deleted the `getEffectTech` helper function, as techniques are now referenced by name at use time rather than stored as members.

**Rendering logic simplification:**

* Updated all rendering methods (e.g., `draw`, `drawWithMask`, `drawWithRefinedMask`, etc.) to use `gs_effect_loop` with the technique name string, replacing the previous pattern of manually managing technique passes and explicit technique pointers. [[1]](diffhunk://#diff-49445d213c52a4df9c50d0dccf2061b96f0e0f506afdb33260e6267c96831243L173-R142) [[2]](diffhunk://#diff-49445d213c52a4df9c50d0dccf2061b96f0e0f506afdb33260e6267c96831243L219-L222) [[3]](diffhunk://#diff-49445d213c52a4df9c50d0dccf2061b96f0e0f506afdb33260e6267c96831243L237-L248) [[4]](diffhunk://#diff-49445d213c52a4df9c50d0dccf2061b96f0e0f506afdb33260e6267c96831243L261-L271) [[5]](diffhunk://#diff-49445d213c52a4df9c50d0dccf2061b96f0e0f506afdb33260e6267c96831243L288-L336) [[6]](diffhunk://#diff-49445d213c52a4df9c50d0dccf2061b96f0e0f506afdb33260e6267c96831243L354-L379) [[7]](diffhunk://#diff-49445d213c52a4df9c50d0dccf2061b96f0e0f506afdb33260e6267c96831243L397-L423) [[8]](diffhunk://#diff-49445d213c52a4df9c50d0dccf2061b96f0e0f506afdb33260e6267c96831243L440-L465) [[9]](diffhunk://#diff-49445d213c52a4df9c50d0dccf2061b96f0e0f506afdb33260e6267c96831243L482-L509) [[10]](diffhunk://#diff-49445d213c52a4df9c50d0dccf2061b96f0e0f506afdb33260e6267c96831243L523-L536)

**Removal of obsolete code:**

* Removed the `reduce` method from `MainEffect`, as its logic depended on the old technique handling and is no longer compatible with the new approach.

These changes improve maintainability and readability by reducing code duplication and centralizing technique usage patterns.