### PR TITLE
Fix to read plugin properties

### DIFF
--- a/src/Core/MainPluginContext.cpp
+++ b/src/Core/MainPluginContext.cpp
@@ -195,6 +195,10 @@ void MainPluginContext::update(obs_data_t *settings)
 	pluginProperty.maskLowerBound = PluginProperty::dbToLinearAmp(pluginProperty.maskLowerBoundDb);
 	pluginProperty.maskUpperBoundMarginDb = obs_data_get_double(settings, "maskUpperBoundMarginDb");
 	pluginProperty.maskUpperBound = 1.0 - PluginProperty::dbToLinearAmp(pluginProperty.maskUpperBoundMarginDb);
+
+	if (renderingContext) {
+		renderingContext->setPluginProperty(pluginProperty);
+	}
 }
 
 void MainPluginContext::activate() {}


### PR DESCRIPTION
This pull request makes a targeted update to the `MainPluginContext::update` method to ensure that any changes to plugin properties are immediately reflected in the rendering context if it exists. This helps keep the rendering context synchronized with the latest plugin settings.

Synchronization with rendering context:

* Added logic to call `setPluginProperty` on the `renderingContext` object after updating `pluginProperty`, ensuring the rendering context stays up-to-date with the current plugin settings.