### PR TITLE
Automate Arch and Flatpak manifest updates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,7 +24,7 @@
    cp -r ./build_macos/RelWithDebInfo/live-backgroundremoval-lite.plugin ~/Library/Application\ Support/obs-studio/plugins
    ```
 
-## Release Automation with Gemini
+## Release Automation
 
 To initiate a new release, the user will instruct Gemini to start the process (e.g., "リリースを開始して" or "リリースしたい"). Gemini will then perform the following steps:
 
@@ -36,7 +36,10 @@ To initiate a new release, the user will instruct Gemini to start the process (e
 2.  **Prepare & Update `buildspec.json`**:
     * **ACTION**: Confirm the current branch is `main` and synchronized with the remote.
     * **ACTION**: Create a new branch (`bump-X.Y.Z`).
-    * **ACTION**: Update the `version` field in `buildspec.json`.
+    * **ACTION**: Update the `version` field in `buildspec.json` using `jq`, e.g.:
+      ```
+      jq '.version = "<new_version>"' buildspec.json > buildspec.json.tmp && mv buildspec.json.tmp buildspec.json
+      ```
 
 3.  **Create & Merge Pull Request (PR)**:
     * **ACTION**: Create a PR for the version update.
@@ -57,18 +60,12 @@ To initiate a new release, the user will instruct Gemini to start the process (e
     * **ACTION**: Provide the releases URL.
     * **INSTRUCTION**: User completes the release on GitHub.
 
-6.  **Update Arch Linux Package Manifest**:
-    * **ACTION**: Match the `pkgver` field in `unsupported/arch/live-backgroundremoval-lite/PKGBUILD` with the version in `buildspec.json`.
-    * **ACTION**: Download the source tar.gz for that version from GitHub and calculate its SHA-256 checksum.
-    * **ACTION**: Replace the `sha256sums` field in `unsupported/arch/live-backgroundremoval-lite/PKGBUILD` with the newly calculated SHA-256 checksum.
+6.  **Update Arch Linux and Flatpak Package Manifests**:
+    * **ACTION**: Run `unsupported/update-packages.sh <new_version>` to update both Arch Linux and Flatpak manifests automatically.
+    * **ACTION**: Review the changes made by the script.
 
-7.  **Update Flatpak Package Manifest**:
-    * **ACTION**: Add a new `<release>` element to `unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml`.
-    * **ACTION**: The new release element should have the `version` and `date` attributes set to the new version and current date.
-    * **ACTION**: Update the `tag` field for the `live-backgroundremoval-lite` module in `unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml` to the new version.
-    * **ACTION**: Get the commit hash for the new tag by running `git rev-list -n 1 <new_version_tag>`.
-    * **ACTION**: Update the `commit` field for the `live-backgroundremoval-lite` module in `unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml` to the new commit hash.
-
-8.  **Create Pull Request for Manifest Updates**:
-    * **ACTION**: Commit the changes for both files and create a single pull request.
+7.  **Create Pull Request for Manifest Updates**:
+    * **ACTION**: Create a new branch named `unsupported/bump-<new_version>`.
+    * **ACTION**: Commit the changes with the message `chore: Update PKGBUILD and Flatpak for <new_version>`.
+    * **ACTION**: Create a single pull request for these changes.
 

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
@@ -20,17 +20,17 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <releases>
-    <release version="1.8.5" date="2025-10-09" />
-    <release version="1.8.4" date="2025-10-08" />
-    <release version="1.8.3" date="2025-10-04" />
-    <release version="1.8.2" date="2025-10-04" />
-    <release version="1.8.1" date="2025-10-02" />
-    <release version="1.8.0" date="2025-10-01" />
-    <release version="1.7.0" date="2025-09-30" />
-    <release version="1.6.0" date="2025-09-29" />
-    <release version="1.5.1" date="2025-09-27" />
-    <release version="1.5.0" date="2025-09-27" />
-    <release version="1.4.3" date="2025-09-27" />
+    <release version="1.8.5" date="2025-10-09"/>
+    <release version="1.8.4" date="2025-10-08"/>
+    <release version="1.8.3" date="2025-10-04"/>
+    <release version="1.8.2" date="2025-10-04"/>
+    <release version="1.8.1" date="2025-10-02"/>
+    <release version="1.8.0" date="2025-10-01"/>
+    <release version="1.7.0" date="2025-09-30"/>
+    <release version="1.6.0" date="2025-09-29"/>
+    <release version="1.5.1" date="2025-09-27"/>
+    <release version="1.5.0" date="2025-09-27"/>
+    <release version="1.4.3" date="2025-09-27"/>
   </releases>
-  <content_rating type="oars-1.1" />
+  <content_rating type="oars-1.1"/>
 </component>

--- a/unsupported/update-packages.sh
+++ b/unsupported/update-packages.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -euo pipefail
+
+# --- Pre-flight Checks ---
+
+# Check if xmlstarlet is installed.
+if ! command -v xmlstarlet &> /dev/null; then
+    echo "⚠️ Error: 'xmlstarlet' is not installed."
+    echo "Please install it using your system's package manager (e.g., brew install xmlstarlet)."
+    exit 1
+fi
+
+# --- Variables ---
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+ARCH_PKGBUILD_PATH="${REPO_ROOT}/unsupported/arch/live-backgroundremoval-lite/PKGBUILD"
+FLATPAK_YAML_PATH="${REPO_ROOT}/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml"
+FLATPAK_METAINFO_PATH="${REPO_ROOT}/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml"
+REPO_URL="https://github.com/kaito-tokyo/live-backgroundremoval-lite"
+PKG_NAME="live-backgroundremoval-lite"
+
+# --- Main Script ---
+
+# Check for new version argument.
+if [ -z "${1-}" ]; then
+  echo "Usage: $0 <new-version>"
+  echo "Example: $0 1.8.6"
+  exit 1
+fi
+
+NEW_VERSION="${1#v}" # Remove 'v' prefix if it exists
+CURRENT_DATE=$(date +%Y-%m-%d)
+
+echo "🚀 Starting package update for version ${NEW_VERSION}..."
+echo "--------------------------------------------------"
+
+# 1. Update Arch Linux PKGBUILD
+echo "📦 Updating Arch Linux PKGBUILD..."
+DOWNLOAD_URL="${REPO_URL}/archive/refs/tags/${NEW_VERSION}.tar.gz"
+echo "  Downloading source to calculate checksum..."
+SHA256_SUM=$(curl -sL "${DOWNLOAD_URL}" | sha256sum | awk '{print $1}')
+
+if [ -z "${SHA256_SUM}" ]; then
+    echo "❌ Error: Failed to calculate SHA256 checksum. Please check the URL."
+    exit 1
+fi
+
+sed -i '' -e "s/^pkgver=.*/pkgver=${NEW_VERSION}/" "${ARCH_PKGBUILD_PATH}"
+sed -i '' -e "s/^sha256sums=('.*')/sha256sums=('${SHA256_SUM}')/" "${ARCH_PKGBUILD_PATH}"
+echo "  ✅ PKGBUILD updated."
+echo "--------------------------------------------------"
+
+# 2. Update Flatpak Manifests
+echo "📦 Updating Flatpak manifests..."
+echo "  Fetching git commit hash for tag '${NEW_VERSION}'..."
+COMMIT_HASH=$(git rev-list -n 1 "${NEW_VERSION}")
+
+if [ -z "${COMMIT_HASH}" ]; then
+    echo "❌ Error: Git tag '${NEW_VERSION}' not found."
+    exit 1
+fi
+
+# Update YAML file (macOS/BSD sed compatible)
+sed -i '' "/name: ${PKG_NAME}/,/- type: git/{
+s/tag: .*/tag: ${NEW_VERSION}/
+s/commit: .*/commit: '${COMMIT_HASH}'/
+}" "${FLATPAK_YAML_PATH}"
+
+# Update metainfo.xml file
+xmlstarlet ed -L \
+    -i "/component/releases/release[1]" -t elem -n "release" \
+    -i "/component/releases/release[1]" -t attr -n "version" -v "${NEW_VERSION}" \
+    -i "/component/releases/release[1]" -t attr -n "date" -v "${CURRENT_DATE}" \
+    "${FLATPAK_METAINFO_PATH}"
+
+echo "  ✅ Flatpak manifests updated."
+echo "--------------------------------------------------"
+
+echo "🎉 All package manifests have been updated successfully!"
+echo "Please review the changes with 'git status' and create a pull request."


### PR DESCRIPTION
This pull request streamlines and automates the process for updating Arch Linux and Flatpak package manifests during a release. The instructions in `.github/copilot-instructions.md` have been simplified to use a new script, and the script itself (`unsupported/update-packages.sh`) has been added to automate the required updates.

**Release process documentation improvements:**

* The release automation instructions in `.github/copilot-instructions.md` have been updated to remove references to Gemini and simplify the steps for updating package manifests, now recommending the use of a single script to automate updates for both Arch Linux and Flatpak. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L27-R27) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L60-R70)
* Added a usage example for updating the `version` field in `buildspec.json` using `jq` for clarity and reproducibility.

**Release automation tooling:**

* Introduced the new `unsupported/update-packages.sh` script, which automatically updates the Arch Linux PKGBUILD and Flatpak manifests, including version bumps, checksum calculation, and Flatpak release metadata. The script includes error handling and pre-flight checks for required dependencies.Updated release instructions to use a new script for automating Arch Linux and Flatpak manifest updates. Added 'unsupported/update-packages.sh' to handle version bumps and checksum updates for both package types. Minor formatting changes in Flatpak metainfo XML for consistency.