### PR TITLE
chore: Update PKGBUILD and Flatpak for 1.8.6

### DIFF
--- a/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
+++ b/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kaito Udagawa <umireon at kaito dot tokyo>
 pkgname=live-backgroundremoval-lite
-pkgver=1.8.5
+pkgver=1.8.6
 pkgrel=1
 pkgdesc='Live Background Removal Lite for OBS Studio'
 arch=('x86_64')
@@ -10,7 +10,7 @@ depends=('obs-studio' 'curl' 'fmt' 'ncnn' 'opencv')
 makedepends=('git' 'cmake' 'ninja')
 conflicts=("${pkgname}-git" "${pkgname}-git-debug")
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/kaito-tokyo/$pkgname/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('152746b203a81508ad03eb3494834a2cd9066ef58c75ad0949d3e398079846bf')
+sha256sums=('a4fb1d6c27c1e2078978f3abf0a4653505e30ee698823fd8b4e056965a44bed7')
 
 build() {
   cd "${pkgname}-${pkgver}"

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
@@ -20,6 +20,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <releases>
+    <release version="1.8.6" date="2025-10-11"/>
     <release version="1.8.5" date="2025-10-09"/>
     <release version="1.8.4" date="2025-10-08"/>
     <release version="1.8.3" date="2025-10-04"/>


### PR DESCRIPTION
This pull request updates the packaging and metadata for the `live-backgroundremoval-lite` plugin to reflect the new version 1.8.6. The changes ensure that both the Arch PKGBUILD and Flatpak metadata are consistent with the latest release.

Version update and release tracking:

* Updated the `pkgver` in `PKGBUILD` from 1.8.5 to 1.8.6 to package the new release.
* Updated the `sha256sums` in `PKGBUILD` to match the new source tarball for version 1.8.6.
* Added a new `<release>` entry for version 1.8.6 in the Flatpak metainfo XML file to track the latest release date.