### PR TITLE
Flatpak build

### DIFF
--- a/.github/workflows/my-unsupported-build.yaml
+++ b/.github/workflows/my-unsupported-build.yaml
@@ -81,7 +81,7 @@ jobs:
         uses: "actions/checkout@v5"
 
       - name: "Build Flatpak"
-        uses: "flatpak/flatpak-github-actions/flatpak-builder@v6"
+        uses: "flatpak/flatpak-github-actions/flatpak-builder@10a3c29f0162516f0f68006be14c92f34bd4fa6c"
         with:
           bundle: "com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite"
           manifest-path: "unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml"


### PR DESCRIPTION
This pull request adds a new build job for Flatpak packages to the GitHub Actions workflow. The main change is the introduction of a dedicated `BuildFlatpak` job that runs in a containerized environment using a Flatpak-specific image and builder action.

**New Flatpak build workflow:**

* Added a `BuildFlatpak` job to `.github/workflows/my-unsupported-build.yaml` that runs on `ubuntu-24.04` using the `ghcr.io/flathub-infra/flatpak-github-actions:kde-6.8` container image.
* Configured the job to use the `flatpak/flatpak-github-actions/flatpak-builder` GitHub Action for building the Flatpak bundle `com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite` from the manifest at `unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.yaml`.