### PR TITLE
chore: Update PKGBUILD and Flatpak for 1.8.7

### DIFF
--- a/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
+++ b/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kaito Udagawa <umireon at kaito dot tokyo>
 pkgname=live-backgroundremoval-lite
-pkgver=1.8.6
+pkgver=1.8.7
 pkgrel=1
 pkgdesc='Live Background Removal Lite for OBS Studio'
 arch=('x86_64')
@@ -10,7 +10,7 @@ depends=('obs-studio' 'curl' 'fmt' 'ncnn' 'opencv')
 makedepends=('git' 'cmake' 'ninja')
 conflicts=("${pkgname}-git" "${pkgname}-git-debug")
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/kaito-tokyo/$pkgname/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('a4fb1d6c27c1e2078978f3abf0a4653505e30ee698823fd8b4e056965a44bed7')
+sha256sums=('96d441f82a572737fb681eabe71ff3f3fc579c6b6fc8989211f0df1d19e0f6c3')
 
 build() {
   cd "${pkgname}-${pkgver}"

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.json
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.json
@@ -153,7 +153,7 @@
           "type": "git",
           "url": "https://github.com/kaito-tokyo/live-backgroundremoval-lite.git",
           "tag": "1.8.7",
-          "commit": "0929e9c47c62a9184b69162adcd53d9b60a9dcf1",
+          "commit": "7c10b5d6f27b961ae60da898bba482a58a2e0c5f",
           "x-checker-data": {
             "type": "git",
             "tag-pattern": "^([\\d.]+)$"

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
@@ -20,6 +20,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <releases>
+    <release version="1.8.7" date="2025-10-11"/>
     <release version="1.8.6" date="2025-10-11"/>
     <release version="1.8.5" date="2025-10-09"/>
     <release version="1.8.4" date="2025-10-08"/>


### PR DESCRIPTION
This pull request updates the Live Background Removal Lite plugin for OBS Studio to version 1.8.7 across both Arch and Flatpak packaging. The changes ensure consistency in versioning and integrity checks, and document the new release.

Version and integrity updates:

* Bumped the package version from `1.8.6` to `1.8.7` in `PKGBUILD`, and updated the corresponding source archive SHA256 checksum for the new release. [[1]](diffhunk://#diff-83756e3d4361f41f9db1d048bf05d7c41aae46b964eafa44318c2a062058d7fbL3-R3) [[2]](diffhunk://#diff-83756e3d4361f41f9db1d048bf05d7c41aae46b964eafa44318c2a062058d7fbL13-R13)
* Updated the Flatpak manifest to use git tag `1.8.7` and the corresponding commit hash for the plugin source.

Release documentation:

* Added a new release entry for version `1.8.7` in the Flatpak metainfo XML to document the update.