### PR TITLE
Move MacOS Homebrew test job to unsupported workflow

### DIFF
--- a/.github/workflows/my-testing.yaml
+++ b/.github/workflows/my-testing.yaml
@@ -68,26 +68,6 @@ jobs:
       - name: "Run tests"
         run: "ctest --preset macos --verbose"
 
-  TestOnMacOSHomebrew:
-    runs-on: "macos-15"
-    timeout-minutes: 30
-
-    steps:
-      - name: "Checkout project repository"
-        uses: "actions/checkout@v5"
-
-      - name: "Install dependencies"
-        run: "brew install fmt ncnn opencv"
-
-      - name: "Configure"
-        run: "cmake --preset macos-homebrew"
-        
-      - name: "Build"
-        run: "cmake --build --preset macos-homebrew"
-
-      - name: "Run tests"
-        run: "ctest --preset macos-homebrew --verbose"
-
   TestOnWindows:
     runs-on: "windows-2022"
     timeout-minutes: 30

--- a/.github/workflows/my-unsupported-build.yaml
+++ b/.github/workflows/my-unsupported-build.yaml
@@ -21,6 +21,26 @@ permissions:
   contents: "read"
 
 jobs:
+  TestOnMacOSHomebrew:
+    runs-on: "macos-15"
+    timeout-minutes: 30
+
+    steps:
+      - name: "Checkout project repository"
+        uses: "actions/checkout@v5"
+
+      - name: "Install dependencies"
+        run: "brew install fmt googletest ncnn opencv"
+
+      - name: "Configure"
+        run: "cmake --preset macos-homebrew"
+        
+      - name: "Build"
+        run: "cmake --build --preset macos-homebrew"
+
+      - name: "Run tests"
+        run: "ctest --preset macos-homebrew --verbose"
+
   BuildOnArch:
     runs-on: "ubuntu-24.04"
 

--- a/src/Core/MainPluginContext.cpp
+++ b/src/Core/MainPluginContext.cpp
@@ -24,7 +24,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <obs-module.h>
 #include <obs-frontend-api.h>
 
+#ifdef PREFIXED_NCNN_HEADERS
+#include <ncnn/gpu.h>
+#else
 #include <gpu.h>
+#endif
 
 #include "../BridgeUtils/GsUnique.hpp"
 #include "../BridgeUtils/ObsLogger.hpp"

--- a/src/Core/MainPluginContext.h
+++ b/src/Core/MainPluginContext.h
@@ -29,12 +29,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <memory>
 #include <mutex>
 
-#ifdef PREFIXED_NCNN_HEADERS
-#include <ncnn/net.h>
-#else
-#include <net.h>
-#endif
-
 #include "../BridgeUtils/ILogger.hpp"
 #include "../BridgeUtils/ThrottledTaskQueue.hpp"
 


### PR DESCRIPTION
This pull request updates the CI configuration and refines header inclusion logic for the NCNN library in the core plugin source files. The main changes are the migration of the `TestOnMacOSHomebrew` job between workflow files and improvements to conditional header inclusion for better compatibility.

**CI Workflow Updates:**

* The `TestOnMacOSHomebrew` job was removed from `.github/workflows/my-testing.yaml` and added to `.github/workflows/my-unsupported-build.yaml`, with dependency installation updated to include `googletest` alongside existing packages. [[1]](diffhunk://#diff-869501959e8df31899edc97e86a54cfe980435783553606f60a82607df960f92L71-L90) [[2]](diffhunk://#diff-ca7fdb6e9f2fd5b2473f9d3c570a14954cf24405738d4dbb8c601a8c33c93d92R24-R43)

**NCNN Header Inclusion Refinement:**

* In `src/Core/MainPluginContext.cpp`, the inclusion of the `ncnn/gpu.h` header is now conditional based on the `PREFIXED_NCNN_HEADERS` macro, improving compatibility with different NCNN installations.
* In `src/Core/MainPluginContext.h`, all conditional inclusion logic for `ncnn/net.h` was removed, likely streamlining the header management and reducing complexity.The TestOnMacOSHomebrew job was removed from my-testing.yaml and added to my-unsupported-build.yaml, with googletest added to the dependencies. Also, conditional inclusion of ncnn headers in MainPluginContext.cpp was updated, and redundant conditional includes in MainPluginContext.h were removed.