### PR TITLE
Update CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -208,6 +208,11 @@
       "configuration": "RelWithDebInfo"
     },
     {
+      "name": "macos-homebrew",
+      "configurePreset": "macos-homebrew",
+      "configuration": "RelWithDebInfo"
+    },
+    {
       "name": "windows-x64",
       "configurePreset": "windows-x64",
       "configuration": "RelWithDebInfo"


### PR DESCRIPTION
This pull request introduces a new build preset for macOS environments using Homebrew in the `CMakePresets.json` file. This addition allows developers to easily configure and build the project with dependencies managed by Homebrew.

* Build configuration update:
  * Added a new `macos-homebrew` preset to `CMakePresets.json` to support building on macOS systems with Homebrew-managed dependencies.