### PR TITLE
chore: Bump version to 2.0.1

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -38,7 +38,7 @@
   },
   "name": "live-backgroundremoval-lite",
   "displayName": "Live Background Removal Lite",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Kaito Udagawa",
   "website": "https://kaito-tokyo.github.io/live-backgroundremoval-lite/",
   "email": "umireon@kaito.tokyo"


### PR DESCRIPTION
This pull request updates the version number in the `buildspec.json` file to reflect a new release.

* Version bump: Updated the `version` field from `2.0.0` to `2.0.1` in `buildspec.json` to indicate a new release.