### PR TITLE
chore: Update PKGBUILD and Flatpak for 2.0.1

### DIFF
--- a/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
+++ b/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kaito Udagawa <umireon at kaito dot tokyo>
 pkgname=live-backgroundremoval-lite
-pkgver=2.0.0
+pkgver=2.0.1
 pkgrel=1
 pkgdesc='Live Background Removal Lite for OBS Studio'
 arch=('x86_64')
@@ -10,7 +10,7 @@ depends=('obs-studio' 'curl' 'fmt' 'ncnn' 'opencv')
 makedepends=('git' 'cmake' 'ninja')
 conflicts=("${pkgname}-git" "${pkgname}-git-debug")
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/kaito-tokyo/$pkgname/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('975ae56dc0aec9e6bac6e1fa8f28ae9f58eb74625cc51e19d8e3984eef86e1db')
+sha256sums=('1af861efebd8afd82cadb03c252a93c13f63001444b2f2b9d0f3aaa066818238')
 
 build() {
   cd "${pkgname}-${pkgver}"

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.json
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.json
@@ -152,8 +152,8 @@
         {
           "type": "git",
           "url": "https://github.com/kaito-tokyo/live-backgroundremoval-lite.git",
-          "tag": "2.0.0",
-          "commit": "cec17683d2c62e2276d9ef27be0e21011cf42e02",
+          "tag": "2.0.1",
+          "commit": "a002498b297fe3aaf6df6913a54ae5eb27a17e84",
           "x-checker-data": {
             "type": "git",
             "tag-pattern": "^([\\d.]+)$"

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
@@ -20,6 +20,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <releases>
+    <release version="2.0.1" date="2025-10-12"/>
     <release version="2.0.0" date="2025-10-12"/>
     <release version="1.8.7" date="2025-10-11"/>
     <release version="1.8.6" date="2025-10-11"/>


### PR DESCRIPTION
This pull request updates the packaging for `live-backgroundremoval-lite` to reflect the new upstream release version 2.0.1. The changes ensure that all build scripts and metadata reference the latest version and its associated checksums and commit hashes.

Version update and metadata synchronization:

* Updated the `pkgver` in `PKGBUILD` to 2.0.1 and changed the source archive checksum to match the new release. [[1]](diffhunk://#diff-83756e3d4361f41f9db1d048bf05d7c41aae46b964eafa44318c2a062058d7fbL3-R3) [[2]](diffhunk://#diff-83756e3d4361f41f9db1d048bf05d7c41aae46b964eafa44318c2a062058d7fbL13-R13)
* Updated the Flatpak manifest `com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.json` to reference tag 2.0.1 and its corresponding commit hash.
* Added a new release entry for version 2.0.1 in the metainfo XML file `com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml`.