### PR TITLE
chore: Bump version to 2.1.0

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -38,7 +38,7 @@
   },
   "name": "live-backgroundremoval-lite",
   "displayName": "Live Background Removal Lite",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "author": "Kaito Udagawa",
   "website": "https://kaito-tokyo.github.io/live-backgroundremoval-lite/",
   "email": "umireon@kaito.tokyo"


### PR DESCRIPTION
This pull request includes a minor version bump for the `live-backgroundremoval-lite` package, updating the version from `2.0.1` to `2.1.0`. This change prepares the package for a new release and signals to users that new features or improvements have been made.