### PR TITLE
chore: Update PKGBUILD and Flatpak for 2.2.0

### DIFF
--- a/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
+++ b/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kaito Udagawa <umireon at kaito dot tokyo>
 pkgname=live-backgroundremoval-lite
-pkgver=2.1.0
+pkgver=2.2.0
 pkgrel=1
 pkgdesc='Live Background Removal Lite for OBS Studio'
 arch=('x86_64')
@@ -10,7 +10,7 @@ depends=('obs-studio' 'curl' 'fmt' 'ncnn' 'opencv')
 makedepends=('git' 'cmake' 'ninja')
 conflicts=("${pkgname}-git" "${pkgname}-git-debug")
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/kaito-tokyo/$pkgname/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('13ca3ca3e6b1688ebd16d833b8da5bce7e14c0ca666939e54daa4024b152916d')
+sha256sums=('029a4367f15ad0ae73ccc4061a76a20d70523e52baa2a754b87d82683c22d757')
 
 build() {
   cd "${pkgname}-${pkgver}"

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.json
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.json
@@ -152,8 +152,8 @@
         {
           "type": "git",
           "url": "https://github.com/kaito-tokyo/live-backgroundremoval-lite.git",
-          "tag": "2.1.1",
-          "commit": "4e9b4468cc506a677e019c1f1fe958ebd1fb1b6c",
+          "tag": "2.2.0",
+          "commit": "8af4badfb19b0efc19f8b0a5645584f6b7f97416",
           "x-checker-data": {
             "type": "git",
             "tag-pattern": "^([\\d.]+)$"

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
@@ -20,6 +20,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <releases>
+    <release version="2.2.0" date="2025-10-17"/>
     <release version="2.1.0" date="2025-10-13"/>
     <release version="2.0.1" date="2025-10-12"/>
     <release version="2.0.0" date="2025-10-12"/>


### PR DESCRIPTION
This pull request updates the Live Background Removal Lite plugin for OBS Studio to version 2.2.0 across packaging files. The changes ensure that all package definitions and metadata reflect the new release, including updated checksums and source references.

Version and source updates:

* Bumped the package version to `2.2.0` in the `PKGBUILD` file and updated the source tarball checksum to match the new release. [[1]](diffhunk://#diff-83756e3d4361f41f9db1d048bf05d7c41aae46b964eafa44318c2a062058d7fbL3-R3) [[2]](diffhunk://#diff-83756e3d4361f41f9db1d048bf05d7c41aae46b964eafa44318c2a062058d7fbL13-R13)
* Updated the Flatpak manifest (`com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.json`) to use tag `2.2.0` and the corresponding commit hash for the source.

Metadata update:

* Added a new release entry for version `2.2.0` with the release date in the Flatpak metainfo file (`com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml`).This pull request updates the Live Background Removal Lite plugin for OBS Studio to version 2.2.0 across packaging files. The changes ensure the latest release is used for both Arch and Flatpak distributions and update related metadata and verification hashes.

**Version bump and packaging updates:**

* Updated `pkgver` to `2.2.0` in `PKGBUILD` for Arch packaging, ensuring the latest plugin version is used.
* Changed the source archive hash in `PKGBUILD` to match the new release, ensuring package integrity verification works for version 2.2.0.
* Updated the Flatpak build manifest (`com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.json`) to use tag `2.2.0` and the corresponding commit, so Flatpak builds pull the correct version.

**Metadata update:**

* Added a new release entry for version 2.2.0 in the Flatpak metainfo XML (`com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml`), reflecting the latest release date and version in user-facing metadata.