### PR TITLE
Strict sync 2

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -5,13 +5,9 @@ updateCheckerPluginIsLatest="Your plugin is up to date."
 updateCheckerUpdateAvailable="A new version of the plugin is available."
 updateCheckerCheckingError="Error checking for updates."
 
-computeUnit="Compute Unit"
-computeUnitAuto="Auto"
-computeUnitCpuOnly="CPU Only"
-computeUnitVulkanGpu="ncnn Vulkan GPU"
-computeUnitCoreML="CoreML"
+showDebugWindow="Show Debug Window"
 
-numThreads="Number of Threads"
+isStrictlySyncing="Strictly Matte Sync (Huge Performance Impact)"
 
 filterLevel="Filter Level"
 filterLevelDefault="Default"
@@ -20,16 +16,20 @@ filterLevelSegmentation="200 - Segmentation"
 filterLevelGuidedFilter="300 - Guided Filter"
 filterLevelTimeAveragedFilter="400 - Time-Averaged Filter"
 
-isStrictlySyncing="Strictly Matte Sync (Huge Performance Impact)"
+selfieSegmenterFps="Selfie Segmenter Maximum FPS (0 for Auto)"
 
-selfieSegmenterFps="Selfie Segmenter Maximum FPS"
+computeUnit="Compute Unit"
+computeUnitAuto="Auto"
+computeUnitCpuOnly="CPU Only"
+computeUnitVulkanGpu="ncnn Vulkan GPU"
+computeUnitCoreML="CoreML"
+
+numThreads="Number of Threads"
 
 guidedFilterEpsPowDb="Guided Filter Eps [dB]"
+
+timeAveragedFilteringAlpha="Time-Averaged Filtering Alpha"
 
 maskGamma="Mask Gamma"
 maskLowerBoundAmpDb="Mask Lower Bound [dB]"
 maskUpperBoundMarginAmpDb="Mask Upper Bound Margin [dB]"
-
-timeAveragedFilteringAlpha="Time-Averaged Filtering Alpha"
-
-showDebugWindow="Show Debug Window"

--- a/data/locale/ja-JP.ini
+++ b/data/locale/ja-JP.ini
@@ -5,13 +5,9 @@ updateCheckerPluginIsLatest="プラグインは最新の状態です。"
 updateCheckerUpdateAvailable="新しいバージョンのプラグインが利用可能です。"
 updateCheckerCheckingError="更新の確認中にエラーが発生しました。"
 
-computeUnit="計算ユニット"
-computeUnitAuto="自動"
-computeUnitCpuOnly="CPUのみ"
-computeUnitVulkanGpu="ncnn Vulkan GPU"
-computeUnitCoreML="CoreML"
+showDebugWindow="デバッグウィンドウを表示"
 
-numThreads="スレッド数"
+isStrictlySyncing="厳密な切り抜き同期（パフォーマンスに大きな影響）"
 
 filterLevel="フィルターレベル"
 filterLevelDefault="デフォルト"
@@ -20,9 +16,15 @@ filterLevelSegmentation="200 - セグメンテーション"
 filterLevelGuidedFilter="300 - ガイド付きフィルター"
 filterLevelTimeAveragedFilter="400 - 時間平均フィルター"
 
-isStrictlySyncing="厳密な切り抜き同期（パフォーマンスに大きな影響）"
+selfieSegmenterFps="背景除去AI最大FPS（0で自動）"
 
-selfieSegmenterFps="背景除去AI最大FPS"
+computeUnit="計算ユニット"
+computeUnitAuto="自動"
+computeUnitCpuOnly="CPUのみ"
+computeUnitVulkanGpu="ncnn Vulkan GPU"
+computeUnitCoreML="CoreML"
+
+numThreads="スレッド数"
 
 guidedFilterEpsPowDb="ガイド付きフィルターEps [dB]"
 
@@ -31,5 +33,3 @@ timeAveragedFilteringAlpha="時間平均フィルタリング係数"
 maskGamma="マスクガンマ"
 maskLowerBoundAmpDb="マスク下限 [dB]"
 maskUpperBoundMarginAmpDb="マスク上限マージン [dB]"
-
-showDebugWindow="デバッグウィンドウを表示"

--- a/src/Core/PluginProperty.hpp
+++ b/src/Core/PluginProperty.hpp
@@ -47,7 +47,7 @@ struct PluginProperty {
 
 	bool isStrictlySyncing = false;
 
-	int selfieSegmenterFps = 60;
+	int selfieSegmenterFps = 0;
 
 	int subsamplingRate = 4;
 

--- a/src/Core/RenderingContext.cpp
+++ b/src/Core/RenderingContext.cpp
@@ -141,14 +141,13 @@ void RenderingContext::videoTick(float seconds)
 {
 	FilterLevel _filterLevel = filterLevel;
 
-	float _selfieSegmenterFps = selfieSegmenterFps;
+	float _selfieSegmenterInterval = selfieSegmenterInterval;
 
 	if (_filterLevel >= FilterLevel::Segmentation) {
 		timeSinceLastSelfieSegmentation += seconds;
-		const float interval = 1.0f / _selfieSegmenterFps;
 
-		if (timeSinceLastSelfieSegmentation >= interval) {
-			timeSinceLastSelfieSegmentation -= interval;
+		if (timeSinceLastSelfieSegmentation >= _selfieSegmenterInterval) {
+			timeSinceLastSelfieSegmentation -= _selfieSegmenterInterval;
 			doesNextVideoRenderKickSelfieSegmentation = true;
 		}
 	}

--- a/src/Core/RenderingContext.hpp
+++ b/src/Core/RenderingContext.hpp
@@ -105,7 +105,7 @@ public:
 
 	std::atomic<bool> isStrictlySyncing;
 
-	std::atomic<float> selfieSegmenterFps;
+	std::atomic<float> selfieSegmenterInterval;
 
 	std::atomic<float> guidedFilterEps;
 
@@ -129,31 +129,9 @@ public:
 	{
 
 		if (computeUnit == ComputeUnit::kAuto) {
-			logger.info("Auto-detecting compute unit for selfie segmenter...");
-#ifdef HAVE_COREML_SELFIE_SEGMENTER
-			logger.info("Selecting CoreML on Apple platforms.");
-			return ComputeUnit::kCoreML;
-#elif defined(NCNN_VULKAN)
-#if NCNN_VULKAN == 1
-			if (ncnn::get_gpu_count() > 0) {
-				logger.info(
-					"Vulkan-compatible GPU detected. Selecting ncnn Vulkan backend with GPU index 0.");
-				return ComputeUnit::kNcnnVulkanGpu;
-			} else {
-				logger.info("No Vulkan-compatible GPU detected. Falling back to ncnn CPU.");
-				return ComputeUnit::kCpuOnly;
-			}
-#else
-			logger.info("ncnn built without Vulkan support. Falling back to ncnn CPU.");
+			logger.info("Automatically selecting compute unit...");
+			logger.info("Selecting ncnn CPU backend because it is the most efficient.");
 			return ComputeUnit::kCpuOnly;
-#endif
-#elif defined(__APPLE__)
-			logger.info("Falling back to ncnn CPU backend due to lack of CoreML support.");
-			return ComputeUnit::kCpuOnly;
-#else
-			logger.info("Selecting ncnn CPU backend.");
-			return ComputeUnit::kCpuOnly;
-#endif
 		} else if ((computeUnit & ComputeUnit::kNcnnVulkanGpu) != 0) {
 #ifdef NCNN_VULKAN
 #if NCNN_VULKAN == 1
@@ -200,25 +178,39 @@ public:
 
 	void applyPluginProperty(const PluginProperty &pluginProperty)
 	{
+		isStrictlySyncing = pluginProperty.isStrictlySyncing;
+		logger.info("Strict syncing is {}", isStrictlySyncing.load() ? "enabled" : "disabled");
+
 		if (pluginProperty.filterLevel == FilterLevel::Default) {
 			if (pluginProperty.isStrictlySyncing) {
 				filterLevel = FilterLevel::GuidedFilter;
 			} else {
 				filterLevel = FilterLevel::TimeAveragedFilter;
 			}
+			logger.info("Default filter level is parsed to be {}", static_cast<int>(filterLevel.load()));
 		} else {
 			filterLevel = pluginProperty.filterLevel;
+			logger.info("Filter level set to {}", static_cast<int>(filterLevel.load()));
 		}
-		logger.info("Filter level set to {}", static_cast<int>(filterLevel.load()));
 
-		isStrictlySyncing = pluginProperty.isStrictlySyncing;
-		logger.info("Strict syncing is {}", isStrictlySyncing.load() ? "enabled" : "disabled");
-
-		selfieSegmenterFps = static_cast<float>(pluginProperty.selfieSegmenterFps);
-		logger.info("Selfie segmenter FPS set to {}", selfieSegmenterFps.load());
+		if (pluginProperty.selfieSegmenterFps == 0) {
+			if (pluginProperty.isStrictlySyncing) {
+				selfieSegmenterInterval = 1.0f / 15.0f;
+			} else {
+				selfieSegmenterInterval = 1.0f / 60.0f;
+			}
+			logger.info("Default selfie segmenter interval is parsed to be {}",
+				    selfieSegmenterInterval.load());
+		} else {
+			selfieSegmenterInterval = 1.0f / static_cast<float>(pluginProperty.selfieSegmenterFps);
+		}
+		logger.info("Selfie segmenter interval set to {}", selfieSegmenterInterval.load());
 
 		guidedFilterEps = static_cast<float>(std::pow(10.0, pluginProperty.guidedFilterEpsPowDb / 10.0));
 		logger.info("Guided filter epsilon set to {}", guidedFilterEps.load());
+
+		timeAveragedFilteringAlpha = static_cast<float>(pluginProperty.timeAveragedFilteringAlpha);
+		logger.info("Time-averaged filtering alpha set to {}", timeAveragedFilteringAlpha.load());
 
 		maskGamma = static_cast<float>(pluginProperty.maskGamma);
 		logger.info("Mask gamma set to {}", maskGamma.load());
@@ -229,9 +221,6 @@ public:
 		maskUpperBoundMargin =
 			static_cast<float>(std::pow(10.0, pluginProperty.maskUpperBoundMarginAmpDb / 20.0));
 		logger.info("Mask upper bound margin set to {}", maskUpperBoundMargin.load());
-
-		timeAveragedFilteringAlpha = static_cast<float>(pluginProperty.timeAveragedFilteringAlpha);
-		logger.info("Time-averaged filtering alpha set to {}", timeAveragedFilteringAlpha.load());
 	}
 
 private:


### PR DESCRIPTION
This pull request refactors the selfie segmentation triggering logic in the `RenderingContext` class to improve synchronization and ensure segmentation tasks are kicked at the correct time. The changes introduce a new atomic flag to coordinate when segmentation should be triggered, and adjust the logic for handling filter levels and syncing behavior.

**Selfie segmentation synchronization improvements:**

* Added `doesNextVideoRenderKickSelfieSegmentation` atomic flag to `RenderingContext` to coordinate when segmentation should be triggered. (`src/Core/RenderingContext.hpp`)
* Changed `videoTick` to set `doesNextVideoRenderKickSelfieSegmentation` instead of directly kicking the segmentation task, deferring execution to `videoRender`. (`src/Core/RenderingContext.cpp`)
* Updated `videoRender` to check `doesNextVideoRenderKickSelfieSegmentation` and trigger segmentation either during strict syncing or normal operation, resetting the flag after use. (`src/Core/RenderingContext.cpp`) [[1]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L295-R296) [[2]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7R334-R339)

**Filter level and syncing logic adjustments:**

* Modified `applyPluginProperty` to set the filter level to `GuidedFilter` if strict syncing is enabled and to `TimeAveragedFilter` otherwise, when the default filter level is selected. (`src/Core/RenderingContext.hpp`)