### PR TITLE
Add ncnn::ncnn alias target for Homebrew builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,8 @@ elseif(APPLE AND BUILD_WITH_HOMEBREW)
   find_package(CURL MODULE REQUIRED)
   find_package(fmt CONFIG REQUIRED)
   find_package(ncnn CONFIG REQUIRED)
+
+  add_library(ncnn::ncnn ALIAS ncnn)
 else()
   message(FATAL_ERROR "Either USE_PKGCONFIG or VCPKG_TARGET_TRIPLET must be set.")
 endif()


### PR DESCRIPTION
Defines ncnn::ncnn as an alias for the ncnn target when building on Apple with Homebrew. This improves compatibility with CMake projects expecting the ncnn::ncnn target.