### PR TITLE
Remove checksum generation from release workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -89,18 +89,6 @@ jobs:
             done
           done
 
-      - name: Generate Checksums 🪪
-        if: fromJSON(steps.check.outputs.validTag)
-        run: |
-          : Generate Checksums 🪪
-          if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
-          shopt -s extglob
-
-          echo "### Checksums" > ${{ github.workspace }}/CHECKSUMS.txt
-          for file in ${{ github.workspace }}/@(*.exe|*.deb|*.ddeb|*.pkg|*.tar.xz|*.zip); do
-            echo "    ${file##*/}: $(sha256sum "${file}" | cut -d " " -f 1)" >> ${{ github.workspace }}/CHECKSUMS.txt
-          done
-
       - name: Create Release 🛫
         if: fromJSON(steps.check.outputs.validTag)
         id: create_release
@@ -109,8 +97,7 @@ jobs:
           draft: true
           prerelease: ${{ fromJSON(steps.check.outputs.prerelease) }}
           tag_name: ${{ steps.check.outputs.version }}
-          name: ${{ needs.build-project.outputs.pluginName }} ${{ steps.check.outputs.version }}
-          body_path: ${{ github.workspace }}/CHECKSUMS.txt
+          name: ${{ steps.check.outputs.version }}
           files: |
             ${{ github.workspace }}/*.exe
             ${{ github.workspace }}/*.zip


### PR DESCRIPTION
This pull request updates the release workflow in `.github/workflows/push.yaml` to simplify the release creation process and remove the generation and inclusion of checksum information. The most important changes are listed below.

Release workflow simplification:

* Removed the step that generated a `CHECKSUMS.txt` file containing SHA256 checksums for release artifacts.
* Updated the release creation step to no longer reference the `CHECKSUMS.txt` file in the release body, and simplified the release name to use only the version tag.Eliminates the step that generates CHECKSUMS.txt and updates the release creation to exclude the checksum file in the body. This simplifies the workflow and release process.