### PR TITLE
Remove selfie segmenter FPS property

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -15,8 +15,6 @@ filterLevelMotionIntensityThresholding="300 - Motion Intensity Thresholding"
 filterLevelGuidedFilter="400 - Guided Filter"
 filterLevelTimeAveragedFilter="500 - Time-Averaged Filter"
 
-selfieSegmenterFps="Selfie Segmenter Maximum FPS (0 for Auto)"
-
 numThreads="Number of Threads"
 
 guidedFilterEpsPowDb="Guided Filter Eps [dB]"

--- a/data/locale/ja-JP.ini
+++ b/data/locale/ja-JP.ini
@@ -15,8 +15,6 @@ filterLevelMotionIntensityThresholding="300 - 動き強度閾値処理"
 filterLevelGuidedFilter="400 - ガイド付きフィルター"
 filterLevelTimeAveragedFilter="500 - 時間平均フィルター"
 
-selfieSegmenterFps="背景除去AI最大FPS（0で自動）"
-
 numThreads="スレッド数"
 
 guidedFilterEpsPowDb="ガイド付きフィルターEps [dB]"

--- a/src/Core/MainPluginContext.cpp
+++ b/src/Core/MainPluginContext.cpp
@@ -83,8 +83,6 @@ void MainPluginContext::getDefaults(obs_data_t *data)
 
 	obs_data_set_default_int(data, "filterLevel", static_cast<int>(defaultProperty.filterLevel));
 
-	obs_data_set_default_int(data, "selfieSegmenterFps", defaultProperty.selfieSegmenterFps);
-
 	obs_data_set_default_int(data, "numThreads", defaultProperty.numThreads);
 
 	obs_data_set_default_double(data, "guidedFilterEpsPowDb", defaultProperty.guidedFilterEpsPowDb);
@@ -169,9 +167,6 @@ obs_properties_t *MainPluginContext::getProperties()
 	obs_property_list_add_int(propFilterLevel, obs_module_text("filterLevelTimeAveragedFilter"),
 				  static_cast<int>(FilterLevel::TimeAveragedFilter));
 
-	// Selfie segmenter FPS
-	obs_properties_add_int_slider(props, "selfieSegmenterFps", obs_module_text("selfieSegmenterFps"), 1, 60, 1);
-
 	// Guided filter
 	obs_properties_add_float_slider(props, "guidedFilterEpsPowDb", obs_module_text("guidedFilterEpsPowDb"), -60.0,
 					-20.0, 0.1);
@@ -195,8 +190,6 @@ void MainPluginContext::update(obs_data_t *settings)
 	PluginProperty newPluginProperty;
 
 	newPluginProperty.filterLevel = static_cast<FilterLevel>(obs_data_get_int(settings, "filterLevel"));
-
-	newPluginProperty.selfieSegmenterFps = obs_data_get_int(settings, "selfieSegmenterFps");
 
 	newPluginProperty.guidedFilterEpsPowDb = obs_data_get_double(settings, "guidedFilterEpsPowDb");
 

--- a/src/Core/PluginProperty.hpp
+++ b/src/Core/PluginProperty.hpp
@@ -35,8 +35,6 @@ struct PluginProperty {
 
 	FilterLevel filterLevel = FilterLevel::Default;
 
-	int selfieSegmenterFps = 0;
-
 	int subsamplingRate = 4;
 
 	double guidedFilterEpsPowDb = -40.0;


### PR DESCRIPTION
This pull request removes the configuration option for setting the maximum FPS for the selfie segmenter from both the codebase and the user interface. This affects the plugin's property structure, default settings, and localization files, simplifying the configuration and UI.

**Removal of Selfie Segmenter FPS Configuration:**

* Eliminated the `selfieSegmenterFps` property from the `PluginProperty` struct, removing its usage throughout the codebase (`src/Core/PluginProperty.hpp`).
* Removed default value assignment for `selfieSegmenterFps` in the plugin context (`src/Core/MainPluginContext.cpp`).
* Deleted the slider UI element for configuring selfie segmenter FPS from the plugin properties dialog (`src/Core/MainPluginContext.cpp`).
* Removed logic for updating and reading `selfieSegmenterFps` from settings (`src/Core/MainPluginContext.cpp`).

**Localization updates:**

* Deleted the `selfieSegmenterFps` string from both English and Japanese localization files (`data/locale/en-US.ini`, `data/locale/ja-JP.ini`). [[1]](diffhunk://#diff-b3c242ee2d502c9e6dade4bace60d2ea2ab52969dd96b1cac4ed42f60668b18aL18-L19) [[2]](diffhunk://#diff-4bfd334e089c6795ea16f2a141f4b50c012465a7ecc7f2b61288ab7394070493L18-L19)Eliminated the 'selfieSegmenterFps' property from plugin context, localization files, and PluginProperty struct. This streamlines configuration and removes unused or deprecated functionality related to selfie segmenter FPS.