### PR TITLE
Add motion intensity threshold parameter and refactor processing

### DIFF
--- a/data/effects/main.effect
+++ b/data/effects/main.effect
@@ -108,7 +108,7 @@ float4 PSDrawWithMask(VertInOut vert_in) : TARGET
 	float4 final_color;
 
 	final_color.rgb = image.Sample(point_sampler, uv).rgb;
-	final_color.a = image1.Sample(point_sampler, uv).r;
+	final_color.a = image1.Sample(linear_sampler, uv).r;
 
 	return final_color;
 }

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -19,6 +19,8 @@ advancedSettings="Advanced Settings"
 
 numThreads="Number of Threads"
 
+motionIntensityThresholdPowDb="Motion Intensity Threshold [dB]"
+
 guidedFilterEpsPowDb="Guided Filter Eps [dB]"
 
 timeAveragedFilteringAlpha="Time-Averaged Filtering Alpha"

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -10,20 +10,20 @@ showDebugWindow="Show Debug Window"
 filterLevel="Filter Level"
 filterLevelDefault="Default"
 filterLevelPassthrough="100 - Passthrough"
-filterLevelSegmentation="200 - Segmentation"
+filterLevelSegmentation="200 - AI Segmentation"
 filterLevelMotionIntensityThresholding="300 - Motion Intensity Thresholding"
 filterLevelGuidedFilter="400 - Guided Filter"
 filterLevelTimeAveragedFilter="500 - Time-Averaged Filter"
+
+motionIntensityThresholdPowDb="Motion Intensity Threshold [dB]"
+
+timeAveragedFilteringAlpha="Motion Tracking Speed"
 
 advancedSettings="Advanced Settings"
 
 numThreads="Number of Threads"
 
-motionIntensityThresholdPowDb="Motion Intensity Threshold [dB]"
-
 guidedFilterEpsPowDb="Guided Filter Eps [dB]"
-
-timeAveragedFilteringAlpha="Time-Averaged Filtering Alpha"
 
 maskGamma="Mask Gamma"
 maskLowerBoundAmpDb="Mask Lower Bound [dB]"

--- a/data/locale/ja-JP.ini
+++ b/data/locale/ja-JP.ini
@@ -10,20 +10,20 @@ showDebugWindow="デバッグウィンドウを表示"
 filterLevel="フィルターレベル"
 filterLevelDefault="デフォルト"
 filterLevelPassthrough="100 - パススルー"
-filterLevelSegmentation="200 - セグメンテーション"
+filterLevelSegmentation="200 - AIセグメンテーション"
 filterLevelMotionIntensityThresholding="300 - 動き強度しきい処理"
 filterLevelGuidedFilter="400 - ガイド付きフィルター"
 filterLevelTimeAveragedFilter="500 - 時間平均フィルター"
+
+motionIntensityThresholdPowDb="動き強度しきい値 [dB]"
+
+timeAveragedFilteringAlpha="動き追従速度"
 
 advancedSettings="高度な設定"
 
 numThreads="スレッド数"
 
-motionIntensityThresholdPowDb="動き強度しきい値 [dB]"
-
 guidedFilterEpsPowDb="ガイド付きフィルターEps [dB]"
-
-timeAveragedFilteringAlpha="時間平均フィルタリング係数"
 
 maskGamma="マスクガンマ"
 maskLowerBoundAmpDb="マスク下限 [dB]"

--- a/data/locale/ja-JP.ini
+++ b/data/locale/ja-JP.ini
@@ -11,13 +11,15 @@ filterLevel="フィルターレベル"
 filterLevelDefault="デフォルト"
 filterLevelPassthrough="100 - パススルー"
 filterLevelSegmentation="200 - セグメンテーション"
-filterLevelMotionIntensityThresholding="300 - 動き強度閾値処理"
+filterLevelMotionIntensityThresholding="300 - 動き強度しきい処理"
 filterLevelGuidedFilter="400 - ガイド付きフィルター"
 filterLevelTimeAveragedFilter="500 - 時間平均フィルター"
 
 advancedSettings="高度な設定"
 
 numThreads="スレッド数"
+
+motionIntensityThresholdPowDb="動き強度しきい値 [dB]"
 
 guidedFilterEpsPowDb="ガイド付きフィルターEps [dB]"
 

--- a/src/Core/MainPluginContext.cpp
+++ b/src/Core/MainPluginContext.cpp
@@ -124,22 +124,6 @@ obs_properties_t *MainPluginContext::getProperties()
 	}
 	obs_properties_add_text(props, "isUpdateAvailable", updateAvailableText, OBS_TEXT_INFO);
 
-	// Filter level
-	obs_property_t *propFilterLevel = obs_properties_add_list(props, "filterLevel", obs_module_text("filterLevel"),
-								  OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
-	obs_property_list_add_int(propFilterLevel, obs_module_text("filterLevelDefault"),
-				  static_cast<int>(FilterLevel::Default));
-	obs_property_list_add_int(propFilterLevel, obs_module_text("filterLevelPassthrough"),
-				  static_cast<int>(FilterLevel::Passthrough));
-	obs_property_list_add_int(propFilterLevel, obs_module_text("filterLevelSegmentation"),
-				  static_cast<int>(FilterLevel::Segmentation));
-	obs_property_list_add_int(propFilterLevel, obs_module_text("filterLevelMotionIntensityThresholding"),
-				  static_cast<int>(FilterLevel::MotionIntensityThresholding));
-	obs_property_list_add_int(propFilterLevel, obs_module_text("filterLevelGuidedFilter"),
-				  static_cast<int>(FilterLevel::GuidedFilter));
-	obs_property_list_add_int(propFilterLevel, obs_module_text("filterLevelTimeAveragedFilter"),
-				  static_cast<int>(FilterLevel::TimeAveragedFilter));
-
 	// Debug button
 	obs_properties_add_button2(
 		props, "showDebugWindow", obs_module_text("showDebugWindow"),
@@ -167,17 +151,33 @@ obs_properties_t *MainPluginContext::getProperties()
 		},
 		this);
 
+	// Filter level
+	obs_property_t *propFilterLevel = obs_properties_add_list(props, "filterLevel", obs_module_text("filterLevel"),
+								  OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+	obs_property_list_add_int(propFilterLevel, obs_module_text("filterLevelDefault"),
+				  static_cast<int>(FilterLevel::Default));
+	obs_property_list_add_int(propFilterLevel, obs_module_text("filterLevelPassthrough"),
+				  static_cast<int>(FilterLevel::Passthrough));
+	obs_property_list_add_int(propFilterLevel, obs_module_text("filterLevelSegmentation"),
+				  static_cast<int>(FilterLevel::Segmentation));
+	obs_property_list_add_int(propFilterLevel, obs_module_text("filterLevelMotionIntensityThresholding"),
+				  static_cast<int>(FilterLevel::MotionIntensityThresholding));
+	obs_property_list_add_int(propFilterLevel, obs_module_text("filterLevelGuidedFilter"),
+				  static_cast<int>(FilterLevel::GuidedFilter));
+	obs_property_list_add_int(propFilterLevel, obs_module_text("filterLevelTimeAveragedFilter"),
+				  static_cast<int>(FilterLevel::TimeAveragedFilter));
+
+	// Motion intensity threshold
+	obs_properties_add_float_slider(props, "motionIntensityThresholdPowDb",
+					obs_module_text("motionIntensityThresholdPowDb"), -100.0, 0.0, 0.1);
+
+	// Advanced settings group
 	obs_properties_t *propsAdvancedSettings = obs_properties_create();
 	obs_properties_add_group(props, "advancedSettings", obs_module_text("advancedSettings"), OBS_GROUP_CHECKABLE,
 				 propsAdvancedSettings);
 
 	// Number of threads
-	obs_properties_add_int_slider(propsAdvancedSettings, "numThreads", obs_module_text("numThreads"), 0,
-				      std::thread::hardware_concurrency(), 1);
-
-	// Motion intensity threshold
-	obs_properties_add_float_slider(propsAdvancedSettings, "motionIntensityThresholdPowDb",
-					obs_module_text("motionIntensityThresholdPowDb"), -100.0, 0.0, 0.1);
+	obs_properties_add_int_slider(propsAdvancedSettings, "numThreads", obs_module_text("numThreads"), 0, 16, 2);
 
 	// Guided filter
 	obs_properties_add_float_slider(propsAdvancedSettings, "guidedFilterEpsPowDb",
@@ -206,10 +206,10 @@ void MainPluginContext::update(obs_data_t *settings)
 
 	newPluginProperty.filterLevel = static_cast<FilterLevel>(obs_data_get_int(settings, "filterLevel"));
 
-	if (advancedSettingsEnabled) {
-		newPluginProperty.motionIntensityThresholdPowDb =
-			obs_data_get_double(settings, "motionIntensityThresholdPowDb");
+	newPluginProperty.motionIntensityThresholdPowDb =
+		obs_data_get_double(settings, "motionIntensityThresholdPowDb");
 
+	if (advancedSettingsEnabled) {
 		newPluginProperty.guidedFilterEpsPowDb = obs_data_get_double(settings, "guidedFilterEpsPowDb");
 
 		newPluginProperty.maskGamma = obs_data_get_double(settings, "maskGamma");

--- a/src/Core/MainPluginContext.cpp
+++ b/src/Core/MainPluginContext.cpp
@@ -94,7 +94,6 @@ void MainPluginContext::getDefaults(obs_data_t *data)
 
 	obs_data_set_default_double(data, "guidedFilterEpsPowDb", defaultProperty.guidedFilterEpsPowDb);
 
-
 	obs_data_set_default_double(data, "maskGamma", defaultProperty.maskGamma);
 	obs_data_set_default_double(data, "maskLowerBoundAmpDb", defaultProperty.maskLowerBoundAmpDb);
 	obs_data_set_default_double(data, "maskUpperBoundMarginAmpDb", defaultProperty.maskUpperBoundMarginAmpDb);
@@ -212,8 +211,7 @@ void MainPluginContext::update(obs_data_t *settings)
 	newPluginProperty.motionIntensityThresholdPowDb =
 		obs_data_get_double(settings, "motionIntensityThresholdPowDb");
 
-	newPluginProperty.timeAveragedFilteringAlpha =
-		obs_data_get_double(settings, "timeAveragedFilteringAlpha");
+	newPluginProperty.timeAveragedFilteringAlpha = obs_data_get_double(settings, "timeAveragedFilteringAlpha");
 
 	if (advancedSettingsEnabled) {
 		newPluginProperty.guidedFilterEpsPowDb = obs_data_get_double(settings, "guidedFilterEpsPowDb");

--- a/src/Core/MainPluginContext.cpp
+++ b/src/Core/MainPluginContext.cpp
@@ -83,14 +83,17 @@ void MainPluginContext::getDefaults(obs_data_t *data)
 
 	obs_data_set_default_int(data, "filterLevel", static_cast<int>(defaultProperty.filterLevel));
 
-	obs_data_set_default_int(data, "numThreads", defaultProperty.numThreads);
-
 	obs_data_set_default_double(data, "motionIntensityThresholdPowDb",
 				    defaultProperty.motionIntensityThresholdPowDb);
 
+	obs_data_set_default_double(data, "timeAveragedFilteringAlpha", defaultProperty.timeAveragedFilteringAlpha);
+
+	obs_data_set_default_bool(data, "advancedSettings", false);
+
+	obs_data_set_default_int(data, "numThreads", defaultProperty.numThreads);
+
 	obs_data_set_default_double(data, "guidedFilterEpsPowDb", defaultProperty.guidedFilterEpsPowDb);
 
-	obs_data_set_default_double(data, "timeAveragedFilteringAlpha", defaultProperty.timeAveragedFilteringAlpha);
 
 	obs_data_set_default_double(data, "maskGamma", defaultProperty.maskGamma);
 	obs_data_set_default_double(data, "maskLowerBoundAmpDb", defaultProperty.maskLowerBoundAmpDb);
@@ -171,6 +174,10 @@ obs_properties_t *MainPluginContext::getProperties()
 	obs_properties_add_float_slider(props, "motionIntensityThresholdPowDb",
 					obs_module_text("motionIntensityThresholdPowDb"), -100.0, 0.0, 0.1);
 
+	// Time-averaged filtering
+	obs_properties_add_float_slider(props, "timeAveragedFilteringAlpha",
+					obs_module_text("timeAveragedFilteringAlpha"), 0.0f, 1.0f, 0.01f);
+
 	// Advanced settings group
 	obs_properties_t *propsAdvancedSettings = obs_properties_create();
 	obs_properties_add_group(props, "advancedSettings", obs_module_text("advancedSettings"), OBS_GROUP_CHECKABLE,
@@ -182,10 +189,6 @@ obs_properties_t *MainPluginContext::getProperties()
 	// Guided filter
 	obs_properties_add_float_slider(propsAdvancedSettings, "guidedFilterEpsPowDb",
 					obs_module_text("guidedFilterEpsPowDb"), -60.0, -20.0, 0.1);
-
-	// Time-averaged filtering
-	obs_properties_add_float_slider(propsAdvancedSettings, "timeAveragedFilteringAlpha",
-					obs_module_text("timeAveragedFilteringAlpha"), 0.0f, 1.0f, 0.01f);
 
 	// Mask application
 	obs_properties_add_float_slider(propsAdvancedSettings, "maskGamma", obs_module_text("maskGamma"), 0.5, 3.0,
@@ -209,6 +212,9 @@ void MainPluginContext::update(obs_data_t *settings)
 	newPluginProperty.motionIntensityThresholdPowDb =
 		obs_data_get_double(settings, "motionIntensityThresholdPowDb");
 
+	newPluginProperty.timeAveragedFilteringAlpha =
+		obs_data_get_double(settings, "timeAveragedFilteringAlpha");
+
 	if (advancedSettingsEnabled) {
 		newPluginProperty.guidedFilterEpsPowDb = obs_data_get_double(settings, "guidedFilterEpsPowDb");
 
@@ -216,9 +222,6 @@ void MainPluginContext::update(obs_data_t *settings)
 		newPluginProperty.maskLowerBoundAmpDb = obs_data_get_double(settings, "maskLowerBoundAmpDb");
 		newPluginProperty.maskUpperBoundMarginAmpDb =
 			obs_data_get_double(settings, "maskUpperBoundMarginAmpDb");
-
-		newPluginProperty.timeAveragedFilteringAlpha =
-			obs_data_get_double(settings, "timeAveragedFilteringAlpha");
 	}
 
 	std::shared_ptr<RenderingContext> renderingContext;

--- a/src/Core/MainPluginContext.cpp
+++ b/src/Core/MainPluginContext.cpp
@@ -85,9 +85,12 @@ void MainPluginContext::getDefaults(obs_data_t *data)
 
 	obs_data_set_default_int(data, "numThreads", defaultProperty.numThreads);
 
+	obs_data_set_default_double(data, "motionIntensityThresholdPowDb",
+				    defaultProperty.motionIntensityThresholdPowDb);
+
 	obs_data_set_default_double(data, "guidedFilterEpsPowDb", defaultProperty.guidedFilterEpsPowDb);
 
-	obs_data_set_default_double(data, "timeAveragedFilteringAlpha", 0.1);
+	obs_data_set_default_double(data, "timeAveragedFilteringAlpha", defaultProperty.timeAveragedFilteringAlpha);
 
 	obs_data_set_default_double(data, "maskGamma", defaultProperty.maskGamma);
 	obs_data_set_default_double(data, "maskLowerBoundAmpDb", defaultProperty.maskLowerBoundAmpDb);
@@ -172,6 +175,10 @@ obs_properties_t *MainPluginContext::getProperties()
 	obs_properties_add_int_slider(propsAdvancedSettings, "numThreads", obs_module_text("numThreads"), 0,
 				      std::thread::hardware_concurrency(), 1);
 
+	// Motion intensity threshold
+	obs_properties_add_float_slider(propsAdvancedSettings, "motionIntensityThresholdPowDb",
+					obs_module_text("motionIntensityThresholdPowDb"), -100.0, 0.0, 0.1);
+
 	// Guided filter
 	obs_properties_add_float_slider(propsAdvancedSettings, "guidedFilterEpsPowDb",
 					obs_module_text("guidedFilterEpsPowDb"), -60.0, -20.0, 0.1);
@@ -200,6 +207,9 @@ void MainPluginContext::update(obs_data_t *settings)
 	newPluginProperty.filterLevel = static_cast<FilterLevel>(obs_data_get_int(settings, "filterLevel"));
 
 	if (advancedSettingsEnabled) {
+		newPluginProperty.motionIntensityThresholdPowDb =
+			obs_data_get_double(settings, "motionIntensityThresholdPowDb");
+
 		newPluginProperty.guidedFilterEpsPowDb = obs_data_get_double(settings, "guidedFilterEpsPowDb");
 
 		newPluginProperty.maskGamma = obs_data_get_double(settings, "maskGamma");

--- a/src/Core/PluginProperty.hpp
+++ b/src/Core/PluginProperty.hpp
@@ -40,7 +40,7 @@ struct PluginProperty {
 
 	double guidedFilterEpsPowDb = -40.0;
 
-	double timeAveragedFilteringAlpha = 0.1;
+	double timeAveragedFilteringAlpha = 0.25;
 
 	double maskGamma = 2.5;
 	double maskLowerBoundAmpDb = -25.0;

--- a/src/Core/PluginProperty.hpp
+++ b/src/Core/PluginProperty.hpp
@@ -37,13 +37,15 @@ struct PluginProperty {
 
 	int subsamplingRate = 4;
 
+	double motionIntensityThresholdPowDb = -40.0;
+
 	double guidedFilterEpsPowDb = -40.0;
 
 	double maskGamma = 2.5;
 	double maskLowerBoundAmpDb = -25.0;
 	double maskUpperBoundMarginAmpDb = -25.0;
 
-	double timeAveragedFilteringAlpha = 0.5;
+	double timeAveragedFilteringAlpha = 0.1;
 };
 
 } // namespace LiveBackgroundRemovalLite

--- a/src/Core/PluginProperty.hpp
+++ b/src/Core/PluginProperty.hpp
@@ -32,20 +32,19 @@ enum class FilterLevel : int {
 
 struct PluginProperty {
 	int numThreads = 2;
+	int subsamplingRate = 4;
 
 	FilterLevel filterLevel = FilterLevel::Default;
-
-	int subsamplingRate = 4;
 
 	double motionIntensityThresholdPowDb = -40.0;
 
 	double guidedFilterEpsPowDb = -40.0;
 
+	double timeAveragedFilteringAlpha = 0.1;
+
 	double maskGamma = 2.5;
 	double maskLowerBoundAmpDb = -25.0;
 	double maskUpperBoundMarginAmpDb = -25.0;
-
-	double timeAveragedFilteringAlpha = 0.1;
 };
 
 } // namespace LiveBackgroundRemovalLite

--- a/src/Core/RenderingContext.cpp
+++ b/src/Core/RenderingContext.cpp
@@ -177,7 +177,7 @@ void RenderingContext::videoRender()
 		mainEffect_.drawSource(bgrxSource_, source_);
 	}
 
-	float motionIntensity = processingFrame ? 1.0f : 0.0f;
+	float motionIntensity = (filterLevel < FilterLevel::MotionIntensityThresholding) ? 1.0f : 0.0f;
 
 	if (processingFrame && filterLevel >= FilterLevel::MotionIntensityThresholding) {
 		mainEffect_.convertToLuma(r32fLuma_, bgrxSource_);

--- a/src/Core/RenderingContext.cpp
+++ b/src/Core/RenderingContext.cpp
@@ -193,14 +193,7 @@ void RenderingContext::videoRender()
 		mainEffect_.reduce(r32fMeanSquaredMotionReductionPyramid_, r32fSubPaddedSquaredMotion_);
 
 		r32fReducedMeanSquaredMotionReader_.stage(r32fMeanSquaredMotionReductionPyramid_.back());
-		r32fReducedMeanSquaredMotionReader_.sync();
-
-		const float *meanSquaredMotionPtr =
-			reinterpret_cast<const float *>(r32fReducedMeanSquaredMotionReader_.getBuffer().data());
-		motionIntensity = *meanSquaredMotionPtr / (subRegion_.width * subRegion_.height);
 	}
-
-	const bool isCurrentMotionIntense = (motionIntensity >= motionIntensityThreshold);
 
 	if (processingFrame && filterLevel >= FilterLevel::Segmentation && hasNewSegmenterInput_) {
 		hasNewSegmenterInput_ = false;
@@ -210,6 +203,16 @@ void RenderingContext::videoRender()
 			logger_.error("Failed to sync texture reader: {}", e.what());
 		}
 	}
+
+	if (processingFrame && filterLevel >= FilterLevel::MotionIntensityThresholding) {
+		r32fReducedMeanSquaredMotionReader_.sync();
+
+		const float *meanSquaredMotionPtr =
+			reinterpret_cast<const float *>(r32fReducedMeanSquaredMotionReader_.getBuffer().data());
+		motionIntensity = *meanSquaredMotionPtr / (subRegion_.width * subRegion_.height);
+	}
+
+	const bool isCurrentMotionIntense = (motionIntensity >= motionIntensityThreshold);
 
 	if (processingFrame && filterLevel >= FilterLevel::Segmentation && isCurrentMotionIntense) {
 		constexpr vec4 blackColor = {0.0f, 0.0f, 0.0f, 1.0f};

--- a/src/Core/RenderingContext.cpp
+++ b/src/Core/RenderingContext.cpp
@@ -273,18 +273,24 @@ void RenderingContext::videoRender()
 		auto &bgrxSegmenterInputReaderBuffer = bgrxSegmenterInputReader_.getBuffer();
 		std::copy(bgrxSegmenterInputReaderBuffer.begin(), bgrxSegmenterInputReaderBuffer.end(),
 			  segmenterInputBuffer_.begin());
-		selfieSegmenterTaskQueue_.push(
-			[weakSelf = weak_from_this()](const ThrottledTaskQueue::CancellationToken &token) {
-				if (auto self = weakSelf.lock()) {
-					if (token->load()) {
-						return;
-					}
-					self->selfieSegmenter_->process(self->segmenterInputBuffer_.data());
-					self->hasNewSegmentationMask_.store(true, std::memory_order_release);
-				} else {
-					blog(LOG_INFO, "RenderingContext has been destroyed, skipping segmentation");
+		selfieSegmenterTaskQueue_.push([weakSelf = weak_from_this()](
+						       const ThrottledTaskQueue::CancellationToken &token) {
+			if (auto self = weakSelf.lock()) {
+				if (token->load()) {
+					return;
 				}
-			});
+
+				auto start = std::chrono::steady_clock::now();
+				self->selfieSegmenter_->process(self->segmenterInputBuffer_.data());
+				auto end = std::chrono::steady_clock::now();
+				auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+				self->logger_.info("selfieSegmenter_->process took {} ns", ns);
+
+				self->hasNewSegmentationMask_.store(true, std::memory_order_release);
+			} else {
+				blog(LOG_INFO, "RenderingContext has been destroyed, skipping segmentation");
+			}
+		});
 	}
 }
 

--- a/src/Core/RenderingContext.hpp
+++ b/src/Core/RenderingContext.hpp
@@ -77,11 +77,13 @@ public:
 		}
 		filterLevel_.store(newFilterLevel, std::memory_order_release);
 
-		float newMotionIntensityThreshold = static_cast<float>(std::pow(10.0, pluginProperty.motionIntensityThresholdPowDb / 10.0));
+		float newMotionIntensityThreshold =
+			static_cast<float>(std::pow(10.0, pluginProperty.motionIntensityThresholdPowDb / 10.0));
 		motionIntensityThreshold_.store(newMotionIntensityThreshold, std::memory_order_release);
 		logger_.info("Motion intensity threshold set to {}", newMotionIntensityThreshold);
 
-		float newGuidedFilterEps = static_cast<float>(std::pow(10.0, pluginProperty.guidedFilterEpsPowDb / 10.0));
+		float newGuidedFilterEps =
+			static_cast<float>(std::pow(10.0, pluginProperty.guidedFilterEpsPowDb / 10.0));
 		guidedFilterEps_.store(newGuidedFilterEps, std::memory_order_release);
 		logger_.info("Guided filter epsilon set to {}", newGuidedFilterEps);
 
@@ -97,7 +99,8 @@ public:
 		maskLowerBound_.store(newMaskLowerBound, std::memory_order_release);
 		logger_.info("Mask lower bound set to {}", newMaskLowerBound);
 
-		float newMaskUpperBoundMargin = static_cast<float>(std::pow(10.0, pluginProperty.maskUpperBoundMarginAmpDb / 20.0));
+		float newMaskUpperBoundMargin =
+			static_cast<float>(std::pow(10.0, pluginProperty.maskUpperBoundMarginAmpDb / 20.0));
 		maskUpperBoundMargin_.store(newMaskUpperBoundMargin, std::memory_order_release);
 		logger_.info("Mask upper bound margin set to {}", newMaskUpperBoundMargin);
 	}


### PR DESCRIPTION
This pull request introduces a new configurable "motion intensity threshold" parameter to the plugin, allowing users to control the sensitivity of motion-based filtering. The threshold is exposed in both the UI (with localization for English and Japanese) and the configuration, and is integrated into the core rendering logic. Additionally, the handling of several other filter parameters has been refactored for improved consistency and maintainability.

**Motion Intensity Threshold Feature:**

* Added `motionIntensityThresholdPowDb` as a new configurable property in `PluginProperty`, with a default value and UI slider in advanced settings (English and Japanese localization included). [[1]](diffhunk://#diff-121ed81dad6ffff38730c38361b7ad1ae41523af655c9cd9ffec232702b45dfdR40-R48) [[2]](diffhunk://#diff-053c68a2145dddf96e5da0ca56ee213ce0d2f521b65788494bbdc8eeb570b872R88-R93) [[3]](diffhunk://#diff-053c68a2145dddf96e5da0ca56ee213ce0d2f521b65788494bbdc8eeb570b872R178-R181) [[4]](diffhunk://#diff-b3c242ee2d502c9e6dade4bace60d2ea2ab52969dd96b1cac4ed42f60668b18aR22-R23) [[5]](diffhunk://#diff-4bfd334e089c6795ea16f2a141f4b50c012465a7ecc7f2b61288ab7394070493L14-R23)
* Integrated the new threshold into the rendering logic: segmentation and mask updates now depend on whether the measured motion intensity exceeds the user-defined threshold. [[1]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L162-R182) [[2]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L202-R229) [[3]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L264-L269)

**Refactoring and Consistency Improvements:**

* Refactored `RenderingContext::applyPluginProperty` to consistently use atomic variables and memory orderings for all configurable parameters, including the new motion intensity threshold. [[1]](diffhunk://#diff-d6f55194bdbeca9fe10b2b64c926de60f9c00508ed2c52dc9c5b33ec5c60cb77R70-R102) [[2]](diffhunk://#diff-d6f55194bdbeca9fe10b2b64c926de60f9c00508ed2c52dc9c5b33ec5c60cb77R164-R165)
* Updated default values for several properties (e.g., `timeAveragedFilteringAlpha`) to ensure consistency across initialization and usage. [[1]](diffhunk://#diff-121ed81dad6ffff38730c38361b7ad1ae41523af655c9cd9ffec232702b45dfdR40-R48) [[2]](diffhunk://#diff-053c68a2145dddf96e5da0ca56ee213ce0d2f521b65788494bbdc8eeb570b872R88-R93)
* Improved state tracking in `RenderingContext` by introducing new flags and atomics for managing segmentation mask updates, and removed obsolete member variables. [[1]](diffhunk://#diff-d6f55194bdbeca9fe10b2b64c926de60f9c00508ed2c52dc9c5b33ec5c60cb77R117-R118) [[2]](diffhunk://#diff-d6f55194bdbeca9fe10b2b64c926de60f9c00508ed2c52dc9c5b33ec5c60cb77L123) [[3]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7R286-L286)

These changes make the plugin more configurable and robust, especially for users who need fine control over motion-based filtering behavior.Introduces a configurable motion intensity threshold (in dB) to control segmentation processing, with new UI and localization entries. Refactors RenderingContext to use atomic variables for thread safety, updates property defaults, and improves frame processing logic to respect the new threshold. Also updates Japanese and English locale files for the new parameter.