### PR TITLE
Refactor namespaces and improve config logging

### DIFF
--- a/src/Core/MainEffect.hpp
+++ b/src/Core/MainEffect.hpp
@@ -30,7 +30,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 namespace KaitoTokyo {
 namespace LiveBackgroundRemovalLite {
 
-namespace main_effect_detail {
+namespace MainEffectDetail {
 
 inline gs_eparam_t *getEffectParam(const BridgeUtils::unique_gs_effect_t &effect, const char *name,
 				   const Logger::ILogger &logger)
@@ -45,7 +45,7 @@ inline gs_eparam_t *getEffectParam(const BridgeUtils::unique_gs_effect_t &effect
 	return param;
 }
 
-} // namespace main_effect_detail
+} // namespace MainEffectDetail
 
 struct TransformStateGuard {
 	TransformStateGuard()
@@ -121,17 +121,17 @@ struct MainEffect {
 public:
 	MainEffect(const BridgeUtils::unique_bfree_char_t &effectPath, const Logger::ILogger &logger)
 		: gsEffect(BridgeUtils::make_unique_gs_effect_from_file(effectPath)),
-		  textureImage(main_effect_detail::getEffectParam(gsEffect, "image", logger)),
-		  floatTexelWidth(main_effect_detail::getEffectParam(gsEffect, "texelWidth", logger)),
-		  floatTexelHeight(main_effect_detail::getEffectParam(gsEffect, "texelHeight", logger)),
-		  textureImage1(main_effect_detail::getEffectParam(gsEffect, "image1", logger)),
-		  textureImage2(main_effect_detail::getEffectParam(gsEffect, "image2", logger)),
-		  textureImage3(main_effect_detail::getEffectParam(gsEffect, "image3", logger)),
-		  floatEps(main_effect_detail::getEffectParam(gsEffect, "eps", logger)),
-		  floatGamma(main_effect_detail::getEffectParam(gsEffect, "gamma", logger)),
-		  floatLowerBound(main_effect_detail::getEffectParam(gsEffect, "lowerBound", logger)),
-		  floatUpperBound(main_effect_detail::getEffectParam(gsEffect, "upperBound", logger)),
-		  floatAlpha(main_effect_detail::getEffectParam(gsEffect, "alpha", logger))
+		  textureImage(MainEffectDetail::getEffectParam(gsEffect, "image", logger)),
+		  floatTexelWidth(MainEffectDetail::getEffectParam(gsEffect, "texelWidth", logger)),
+		  floatTexelHeight(MainEffectDetail::getEffectParam(gsEffect, "texelHeight", logger)),
+		  textureImage1(MainEffectDetail::getEffectParam(gsEffect, "image1", logger)),
+		  textureImage2(MainEffectDetail::getEffectParam(gsEffect, "image2", logger)),
+		  textureImage3(MainEffectDetail::getEffectParam(gsEffect, "image3", logger)),
+		  floatEps(MainEffectDetail::getEffectParam(gsEffect, "eps", logger)),
+		  floatGamma(MainEffectDetail::getEffectParam(gsEffect, "gamma", logger)),
+		  floatLowerBound(MainEffectDetail::getEffectParam(gsEffect, "lowerBound", logger)),
+		  floatUpperBound(MainEffectDetail::getEffectParam(gsEffect, "upperBound", logger)),
+		  floatAlpha(MainEffectDetail::getEffectParam(gsEffect, "alpha", logger))
 	{
 	}
 

--- a/src/Core/MainPluginContext.cpp
+++ b/src/Core/MainPluginContext.cpp
@@ -69,12 +69,14 @@ MainPluginContext::~MainPluginContext() noexcept {}
 
 std::uint32_t MainPluginContext::getWidth() const noexcept
 {
-	return renderingContext_ ? renderingContext_->region_.width : 0;
+	auto renderingContext = getRenderingContext();
+	return renderingContext ? renderingContext->region_.width : 0;
 }
 
 std::uint32_t MainPluginContext::getHeight() const noexcept
 {
-	return renderingContext_ ? renderingContext_->region_.height : 0;
+	auto renderingContext = getRenderingContext();
+	return renderingContext ? renderingContext->region_.height : 0;
 }
 
 void MainPluginContext::getDefaults(obs_data_t *data)

--- a/src/Core/PluginConfig.hpp
+++ b/src/Core/PluginConfig.hpp
@@ -56,18 +56,22 @@ struct PluginConfig {
 		PluginConfig pluginConfig;
 
 		if (!data) {
+			logger.info("No config file found, using default configuration");
 			return pluginConfig;
 		}
 
 		if (const char *str = obs_data_get_string(data.get(), "latestVersionURL")) {
+			logger.info("Loaded latestVersionURL from config: {}", str);
 			pluginConfig.latestVersionURL = str;
 		}
 
 		if (const char *str = obs_data_get_string(data.get(), "selfieSegmenterParamPath")) {
+			logger.info("Loaded selfieSegmenterParamPath from config: {}", str);
 			pluginConfig.selfieSegmenterParamPath = str;
 		}
 
 		if (const char *str = obs_data_get_string(data.get(), "selfieSegmenterBinPath")) {
+			logger.info("Loaded selfieSegmenterBinPath from config: {}", str);
 			pluginConfig.selfieSegmenterBinPath = str;
 		}
 


### PR DESCRIPTION
This pull request mainly focuses on improving code consistency and debuggability across several core files. The most notable changes include standardizing namespace naming, updating method calls to match the new namespace, improving logging for configuration loading, and refactoring how rendering context is accessed.

**Code consistency and refactoring:**

* Renamed the namespace from `main_effect_detail` to `MainEffectDetail` in `MainEffect.hpp` to follow a consistent naming convention. [[1]](diffhunk://#diff-49445d213c52a4df9c50d0dccf2061b96f0e0f506afdb33260e6267c96831243L33-R33) [[2]](diffhunk://#diff-49445d213c52a4df9c50d0dccf2061b96f0e0f506afdb33260e6267c96831243L48-R48)
* Updated all references to the old namespace in the `MainEffect` constructor to use the new `MainEffectDetail` namespace.

**Debugging and logging improvements:**

* Added informative logging statements to `PluginConfig::loadFromObsData` to log when default configuration is used and when specific configuration values are loaded, aiding in debugging and traceability.

**Code quality and maintainability:**

* Refactored `MainPluginContext::getWidth()` and `getHeight()` to use the `getRenderingContext()` method instead of directly accessing the member, improving encapsulation and future maintainability.Renamed 'main_effect_detail' namespace to 'MainEffectDetail' in MainEffect.hpp and updated all references accordingly. In MainPluginContext.cpp, switched to using getRenderingContext() for width and height accessors. Enhanced PluginConfig.hpp to add info-level logging when loading configuration values or using defaults.