### PR TITLE
Refactor texture creation with makeTexture helper

### DIFF
--- a/src/Core/RenderingContext.cpp
+++ b/src/Core/RenderingContext.cpp
@@ -46,7 +46,9 @@ inline std::uint32_t bit_ceil(std::uint32_t x)
 
 } // anonymous namespace
 
-BridgeUtils::unique_gs_texture_t RenderingContext::makeTexture(std::uint32_t width, std::uint32_t height, enum gs_color_format color_format, std::uint32_t flags) const noexcept
+BridgeUtils::unique_gs_texture_t RenderingContext::makeTexture(std::uint32_t width, std::uint32_t height,
+							       enum gs_color_format color_format,
+							       std::uint32_t flags) const noexcept
 {
 	unique_gs_texture_t texture = make_unique_gs_texture(width, height, color_format, 1, NULL, flags);
 	TextureRenderGuard renderTargetGuard(texture);
@@ -86,13 +88,11 @@ std::vector<unique_gs_texture_t> RenderingContext::createReductionPyramid(std::u
 		currentWidth = std::max(1u, (currentWidth + 1) / 2);
 		currentHeight = std::max(1u, (currentHeight + 1) / 2);
 
-		pyramid.push_back(
-			makeTexture(currentWidth, currentHeight, GS_R32F, GS_RENDER_TARGET));
+		pyramid.push_back(makeTexture(currentWidth, currentHeight, GS_R32F, GS_RENDER_TARGET));
 	}
 
 	return pyramid;
 }
-
 
 RenderingContext::RenderingContext(obs_source_t *const source, const ILogger &logger, const MainEffect &mainEffect,
 				   ThrottledTaskQueue &selfieSegmenterTaskQueue, const PluginConfig &pluginConfig,
@@ -117,32 +117,27 @@ RenderingContext::RenderingContext(obs_source_t *const source, const ILogger &lo
 	  r32fLuma_(makeTexture(region_.width, region_.height, GS_R32F, GS_RENDER_TARGET)),
 	  r32fSubLumas_{makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET),
 			makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET)},
-	  r32fSubPaddedSquaredMotion_(makeTexture(subPaddedRegion_.width, subPaddedRegion_.height, GS_R32F, GS_RENDER_TARGET)),
+	  r32fSubPaddedSquaredMotion_(
+		  makeTexture(subPaddedRegion_.width, subPaddedRegion_.height, GS_R32F, GS_RENDER_TARGET)),
 	  r32fMeanSquaredMotionReductionPyramid_(
 		  createReductionPyramid(subPaddedRegion_.width, subPaddedRegion_.height)),
 	  r32fReducedMeanSquaredMotionReader_(1, 1, GS_R32F),
 	  bgrxSegmenterInput_(makeTexture(static_cast<std::uint32_t>(selfieSegmenter_->getWidth()),
-						     static_cast<std::uint32_t>(selfieSegmenter_->getHeight()), GS_BGRX, GS_RENDER_TARGET)),
+					  static_cast<std::uint32_t>(selfieSegmenter_->getHeight()), GS_BGRX,
+					  GS_RENDER_TARGET)),
 	  bgrxSegmenterInputReader_(static_cast<std::uint32_t>(selfieSegmenter_->getWidth()),
 				    static_cast<std::uint32_t>(selfieSegmenter_->getHeight()), GS_BGRX),
 	  segmenterInputBuffer_(selfieSegmenter_->getPixelCount() * 4),
 	  r8SegmentationMask_(makeTexture(maskRoi_.width, maskRoi_.height, GS_R8, GS_DYNAMIC)),
-	  r32fSubGFIntermediate_(
-		  makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET)),
-	  r32fSubGFSource_(
-		  makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET)),
-	  r32fSubGFMeanGuide_(
-		  makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET)),
-	  r32fSubGFMeanSource_(
-		  makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET)),
-	  r32fSubGFMeanGuideSource_(
-		  makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET)),
-	  r32fSubGFMeanGuideSq_(
-		  makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET)),
+	  r32fSubGFIntermediate_(makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET)),
+	  r32fSubGFSource_(makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET)),
+	  r32fSubGFMeanGuide_(makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET)),
+	  r32fSubGFMeanSource_(makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET)),
+	  r32fSubGFMeanGuideSource_(makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET)),
+	  r32fSubGFMeanGuideSq_(makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET)),
 	  r32fSubGFA_(makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET)),
 	  r32fSubGFB_(makeTexture(subRegion_.width, subRegion_.height, GS_R32F, GS_RENDER_TARGET)),
-	  r8GuidedFilterResult_(
-		  makeTexture(region_.width, region_.height, GS_R8, GS_RENDER_TARGET)),
+	  r8GuidedFilterResult_(makeTexture(region_.width, region_.height, GS_R8, GS_RENDER_TARGET)),
 	  r8TimeAveragedMasks_{makeTexture(region_.width, region_.height, GS_R8, GS_RENDER_TARGET),
 			       makeTexture(region_.width, region_.height, GS_R8, GS_RENDER_TARGET)}
 {

--- a/src/Core/RenderingContext.hpp
+++ b/src/Core/RenderingContext.hpp
@@ -57,11 +57,13 @@ struct RenderingContextRegion {
 class RenderingContext : public std::enable_shared_from_this<RenderingContext> {
 private:
 	[[nodiscard]]
-	BridgeUtils::unique_gs_texture_t makeTexture(std::uint32_t width, std::uint32_t height, enum gs_color_format color_format, std::uint32_t flags) const noexcept;
+	BridgeUtils::unique_gs_texture_t makeTexture(std::uint32_t width, std::uint32_t height,
+						     enum gs_color_format color_format,
+						     std::uint32_t flags) const noexcept;
 
 	[[nodiscard]]
 	RenderingContextRegion getMaskRoiPosition() const noexcept;
-	
+
 	[[nodiscard]]
 	std::vector<BridgeUtils::unique_gs_texture_t> createReductionPyramid(std::uint32_t width,
 									     std::uint32_t height) const;


### PR DESCRIPTION
This pull request refactors the texture creation logic in the `RenderingContext` class to improve code maintainability and consistency. The main change is the introduction of a new helper method, `makeTexture`, which encapsulates the logic for creating and initializing textures. All direct calls to `make_unique_gs_texture` throughout the class have been replaced with calls to this new method.

Texture creation refactoring:

* Added a private helper method `makeTexture` to the `RenderingContext` class, which handles the creation and initialization of textures, including clearing them to a default color. This centralizes and standardizes texture creation logic. [[1]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7R49-R57) [[2]](diffhunk://#diff-d6f55194bdbeca9fe10b2b64c926de60f9c00508ed2c52dc9c5b33ec5c60cb77R59-R65)
* Updated the `createReductionPyramid` method and all texture member initializations in the `RenderingContext` constructor to use the new `makeTexture` method instead of directly calling `make_unique_gs_texture`. [[1]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L81-R96) [[2]](diffhunk://#diff-a017fe012901aa17cd1346492e8a5fed7758d8c376b4560e6efa3105d993b2f7L106-R147)Introduced a private makeTexture() method in RenderingContext to centralize and simplify gs texture creation. Updated all texture initializations in the constructor and related methods to use this new helper, improving code maintainability and consistency.