### PR TITLE
Update MaskBuffer.hpp

### DIFF
--- a/src/SelfieSegmenter/MaskBuffer.hpp
+++ b/src/SelfieSegmenter/MaskBuffer.hpp
@@ -37,8 +37,8 @@ public:
 	explicit MaskBuffer(std::size_t size)
 		: defaultResource_(*std::pmr::new_delete_resource()),
 		  alignedResource_(kAlignment, &defaultResource_),
-		  buffers_{std::pmr::vector<std::uint8_t>(size, {&alignedResource_}),
-			   std::pmr::vector<std::uint8_t>(size, {&alignedResource_})}
+		  buffers_{std::pmr::vector<std::uint8_t>(size, 0, {&alignedResource_}),
+			   std::pmr::vector<std::uint8_t>(size, 0, {&alignedResource_})}
 	{
 	}
 


### PR DESCRIPTION
This pull request makes a minor update to the initialization of the `buffers_` member in the `MaskBuffer` class constructor. The change ensures that the buffer vectors are explicitly zero-initialized when created, which can help prevent uninitialized memory usage.

- Updated the construction of `buffers_` in `MaskBuffer` to explicitly zero-initialize the buffer contents by passing `0` as the fill value to the `std::pmr::vector` constructor.