### PR TITLE
chore: Bump version to 2.5.2

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -38,7 +38,7 @@
   },
   "name": "live-backgroundremoval-lite",
   "displayName": "Live Background Removal Lite",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "author": "Kaito Udagawa",
   "website": "https://kaito-tokyo.github.io/live-backgroundremoval-lite/",
   "email": "umireon@kaito.tokyo"


### PR DESCRIPTION
This pull request makes a minor update to the project version in the `buildspec.json` file, incrementing it from 2.5.1 to 2.5.2.