### PR TITLE
Add null check for target source in draw method

### DIFF
--- a/src/Core/MainEffect.hpp
+++ b/src/Core/MainEffect.hpp
@@ -143,6 +143,11 @@ public:
 		TextureRenderGuard textureRenderGuard(targetTexture);
 
 		obs_source_t *target = obs_filter_get_target(source);
+		if (target == nullptr) {
+			logger_.error("Failed to get target source for drawing");
+			return;
+		}
+
 		gs_set_render_target_with_color_space(targetTexture.get(), nullptr, GS_CS_709_EXTENDED);
 		while (gs_effect_loop(gsEffect_.get(), "Draw")) {
 			obs_source_video_render(target);


### PR DESCRIPTION
Prevents potential null pointer dereference by checking if the target source is null before proceeding with rendering. Logs an error and returns early if the target is not available.