### PR TITLE
Fix debug window cleanup and initialize member pointers

### DIFF
--- a/src/Core/MainPluginContext.cpp
+++ b/src/Core/MainPluginContext.cpp
@@ -149,8 +149,8 @@ obs_properties_t *MainPluginContext::getProperties()
 
 					newDebugWindow->setAttribute(Qt::WA_DeleteOnClose);
 
-					QObject::connect(newDebugWindow, &QDialog::destroyed,
-							 [newDebugWindow, weakSelf = this_->weak_from_this()]() {
+					QObject::connect(newDebugWindow, &QDialog::finished,
+							 [newDebugWindow, weakSelf = this_->weak_from_this()](int) {
 								 if (auto self = weakSelf.lock()) {
 									 std::lock_guard<std::mutex> lock(
 										 self->debugWindowMutex_);

--- a/src/Core/MainPluginContext.h
+++ b/src/Core/MainPluginContext.h
@@ -88,9 +88,9 @@ private:
 	PluginProperty pluginProperty_;
 
 	mutable std::mutex renderingContextMutex_;
-	std::shared_ptr<RenderingContext> renderingContext_;
+	std::shared_ptr<RenderingContext> renderingContext_ = nullptr;
 
-	DebugWindow *debugWindow_;
+	DebugWindow *debugWindow_ = nullptr;
 	mutable std::mutex debugWindowMutex_;
 };
 


### PR DESCRIPTION
Related to #298

This pull request makes minor improvements to memory management and signal handling for the `DebugWindow` and `RenderingContext` objects in the `MainPluginContext` class. The changes help ensure proper initialization and more robust handling of window closure events.

Initialization improvements:

* Explicitly initializes the `renderingContext_` and `debugWindow_` member variables to `nullptr` in the `MainPluginContext` class to prevent potential issues with uninitialized pointers.

Signal handling update:

* Changes the Qt signal connection for the debug window from `destroyed` to `finished`, ensuring the cleanup logic is triggered when the window is closed via user interaction, not just when the object is destroyed.Changed debug window signal connection from 'destroyed' to 'finished' for proper cleanup. Initialized 'renderingContext_' and 'debugWindow_' member pointers to nullptr in MainPluginContext for safer default state.