### PR TITLE
Add ncnn port to vcpkg overlay

### DIFF
--- a/vcpkg-overlay-ports/ncnn/portfile.cmake
+++ b/vcpkg-overlay-ports/ncnn/portfile.cmake
@@ -1,0 +1,43 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO Tencent/ncnn
+    REF "${VERSION}"
+    SHA512 bb20d8ece3dcddf49530e1ca44eaad1045702b5fb7a7c9cfd6754eb158c7349bba7d63a3ef1e1a4a6e30ed59622367b802f98bf8343bd30ff0cb6def734757c4
+    HEAD_REF master
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" BUILD_SHARED)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        vulkan NCNN_VULKAN
+        vulkan NCNN_SYSTEM_GLSLANG
+)
+
+set(EXTRA_OPTIONS)
+if(VCPKG_TARGET_IS_OSX)
+  message(STATUS "macOS detected: Disabling OpenMP to avoid pthread/libomp issues.")
+  list(APPEND EXTRA_OPTIONS "-DNCNN_OPENMP=OFF")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        ${EXTRA_OPTIONS}
+        -DNCNN_BUILD_TOOLS=OFF
+        -DNCNN_BUILD_EXAMPLES=OFF
+        -DNCNN_BUILD_BENCHMARK=OFF
+        -DNCNN_SHARED_LIB=${BUILD_SHARED}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ncnn)
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/vcpkg-overlay-ports/ncnn/vcpkg.json
+++ b/vcpkg-overlay-ports/ncnn/vcpkg.json
@@ -1,0 +1,27 @@
+{
+  "name": "ncnn",
+  "version": "20250916",
+  "description": "ncnn is a high-performance neural network inference computing framework.",
+  "homepage": "https://github.com/Tencent/ncnn",
+  "license": "BSD-3-Clause",
+  "supports": "!(windows & arm)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "vulkan": {
+      "description": "Enable Vulkan support",
+      "dependencies": [
+        "glslang",
+        "vulkan"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds a new overlay port for the `ncnn` neural network inference framework to the project. The main changes include introducing the port definition and configuration files, specifying dependencies, and handling platform-specific build options.

Addition of new overlay port:

* Added `vcpkg-overlay-ports/ncnn/vcpkg.json` to define the `ncnn` port, including its metadata, dependencies, and optional Vulkan feature support.
* Added `vcpkg-overlay-ports/ncnn/portfile.cmake` to implement the build and installation logic for `ncnn`, including platform-specific options for macOS and disabling unnecessary components like tools, examples, and benchmarks.Introduces portfile.cmake and vcpkg.json for the ncnn library, enabling its installation via vcpkg overlay ports. Includes Vulkan feature support and disables tools, examples, and benchmark builds for streamlined packaging.