### PR TITLE
Add install page and update navigation links

### DIFF
--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -7,6 +7,8 @@ import Layout from "../layouts/Layout.astro";
   title="404 Not Found"
   description="The requested page could not be found."
 >
-  <h1>404 Not Found</h1>
-  <a href="/">Back to Top</a>
+  <main class="white-box">
+    <h1>404 Not Found</h1>
+    <a href="/">Back to Top</a>
+  </main>
 </Layout>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -102,7 +102,7 @@ const structuredData = {
       </div>
       <ul>
         <li>
-          <a href={joinURL(BASE_URL, "installation/")}> How to install? </a>
+          <a href={joinURL(BASE_URL, "install/")}> How to install? </a>
         </li>
       </ul>
     </section>

--- a/docs/src/pages/install.astro
+++ b/docs/src/pages/install.astro
@@ -1,0 +1,94 @@
+---
+import { joinURL } from "ufo";
+import Layout from "../layouts/Layout.astro";
+import { getLatestRelease } from "../lib/github.js";
+import { dependencies, name } from "../../../buildspec.json";
+const githubURL = `https://github.com/kaito-tokyo/${name}`;
+const { BASE_URL } = import.meta.env;
+
+const release = await getLatestRelease();
+const tagName = release.tag_name;
+---
+
+<Layout
+  lang="en"
+  title="How to install?"
+  description="Instructions for installing Live Background Removal Lite on various operating systems."
+>
+  <main class="white-box">
+    <h1>How to install?</h1>
+    <h2>Windows</h2>
+    <ol>
+      <li>
+        <strong>Download:</strong> <a
+          href={joinURL(
+            githubURL,
+            `releases/download/${tagName}/${name}-${tagName}-windows-x64.zip`
+          )}><code>{`${name}-${tagName}-windows-x64.zip`}</code></a> (latest release for Windows)
+      </li>
+      <li>
+    Extract the <code>obs-plugins</code> and <code>data</code> folders from the zip file.<br />
+    Drag and drop the <code>obs-plugins</code> and <code>data</code> folders from the zip file into your OBS Studio installation directory (<code>C:\Program Files\obs-studio</code>), and choose to overwrite when prompted.
+      </li>
+      <li>Restart OBS Studio.</li>
+  <li><strong>Test your installation:</strong> Open OBS Studio, right-click your video source, go to <b>Filters</b>, and check if <b>Live Background Removal Lite</b> appears in the <b>Effect Filters</b> list.<br />
+  For usage instructions, see the <a href={joinURL(BASE_URL, "usage/")}>usage page</a>.</li>
+    </ol>
+
+    <h2>macOS</h2>
+    <ol>
+      <li>
+        <strong>Download:</strong> <a
+          href={joinURL(
+            githubURL,
+            `releases/download/${tagName}/${name}-${tagName}-macos-universal.pkg`
+          )}><code>{`${name}-${tagName}-macos-universal.pkg`}</code></a> (latest release for macOS)
+      </li>
+      <li>
+        Run the installer and follow the prompts to complete installation.
+      </li>
+      <li>Restart OBS Studio.</li>
+      <li><strong>Test your installation:</strong> Open OBS Studio, right-click your video source, go to <b>Filters</b>, and check if <b>Live Background Removal Lite</b> appears in the <b>Effect Filters</b> list.<br />
+      For usage instructions, see the <a href={joinURL(BASE_URL, "usage/")}>usage page</a>.</li>
+    </ol>
+
+    <h2>Ubuntu</h2>
+    <ol>
+      <li>
+        <strong>Download:</strong> <a
+          href={joinURL(
+            githubURL,
+            `releases/download/${tagName}/${name}-${tagName}-x86_64-linux-gnu.deb`
+          )}><code>{`${name}-${tagName}-x86_64-linux-gnu.deb`}</code></a> (latest release for Ubuntu)
+      </li>
+      <li>
+        <strong>Install the package:</strong><br />
+        <ul>
+          <li><strong>Terminal Way:</strong> Open a terminal and run:<br /><code>sudo dpkg -i ./{`${name}-${tagName}-x86_64-linux-gnu.deb`}</code></li>
+          <li><strong>GUI Way:</strong> Double-click the <code>{`${name}-${tagName}-x86_64-linux-gnu.deb`}</code> file in your file manager and follow the on-screen instructions.</li>
+        </ul>
+      </li>
+      <li>Restart OBS Studio.</li>
+      <li><strong>Test your installation:</strong> Open OBS Studio, right-click your video source, go to <b>Filters</b>, and check if <b>Live Background Removal Lite</b> appears in the <b>Effect Filters</b> list.<br />
+      For usage instructions, see the <a href={joinURL(BASE_URL, "usage/")}>usage page</a>.</li>
+    </ol>
+
+    <h2>Arch Linux</h2>
+    <p>
+      For Arch Linux, we provide an <strong>unofficial PKGBUILD</strong> in the repository.<br />
+      You can install this plugin by building with <code>makepkg</code> or using an AUR helper like <code>yay</code>.<br />
+      For detailed instructions, see:<br />
+      <a href={joinURL(githubURL, "tree/main/unsupported/arch/#readme")}>Arch Linux packaging documentation</a>
+    </p>
+
+    <h2>Flatpak</h2>
+    <p>
+      For Flatpak, we provide an <strong>unofficial build definition</strong> in the repository.<br />
+      Users can build and install this plugin using <code>flatpak-builder</code>.<br />
+      For detailed instructions, see:<br />
+      <a href={joinURL(githubURL, "tree/main/unsupported/flatpak/#readme")}>Flatpak packaging documentation</a>
+    </p>
+
+    <a href={joinURL(BASE_URL, "")}>Back to Top</a>
+  </main>
+</Layout>

--- a/docs/src/pages/usage.astro
+++ b/docs/src/pages/usage.astro
@@ -1,7 +1,13 @@
 ---
-import Layout from "../layouts/Layout.astro";
 import { joinURL } from "ufo";
+import Layout from "../layouts/Layout.astro";
+import { getLatestRelease } from "../lib/github.js";
+import { dependencies, name } from "../../../buildspec.json";
+const githubURL = `https://github.com/kaito-tokyo/${name}`;
 const { BASE_URL } = import.meta.env;
+
+const release = await getLatestRelease();
+const tagName = release.tag_name;
 ---
 
 <Layout
@@ -10,13 +16,7 @@ const { BASE_URL } = import.meta.env;
   description="Instructions for installing Live Background Removal Lite on various operating systems."
 >
   <main class="white-box">
-    <h1>How to install?</h1>
-    <h2>Windows</h2>
-    <h2>macOS</h2>
-    <h2>Ubuntu</h2>
-    <h2>Arch Linux</h2>
-    <h2>Flatpak</h2>
-    <h2>Other Linux distributions</h2>
+    <h1>Usage</h1>
     <a href={joinURL(BASE_URL, "")}>Back to Top</a>
   </main>
 </Layout>


### PR DESCRIPTION
This pull request updates the documentation site by reorganizing installation and usage instructions, improving navigation, and adding detailed platform-specific installation steps. The most important changes are the introduction of a new installation guide, the renaming and repurposing of the previous installation page, and improvements to navigation links and page layout.

**Documentation restructuring and new installation guide:**

* Added a comprehensive `install.astro` page with step-by-step installation instructions for Windows, macOS, Ubuntu, Arch Linux, and Flatpak, including direct download links and usage verification steps.
* Renamed `installation.astro` to `usage.astro`, updating its content and metadata to focus on usage instructions rather than installation. [[1]](diffhunk://#diff-d8ce8cac89bff21951d4cacee3b808e1b7a7ad8a7e142e63e919801fadfc152eL2-R10) [[2]](diffhunk://#diff-d8ce8cac89bff21951d4cacee3b808e1b7a7ad8a7e142e63e919801fadfc152eL13-R19)

**Navigation and layout improvements:**

* Updated the homepage link from `installation/` to the new `install/` page for installation instructions.
* Improved the layout of the 404 page by wrapping content in a `main` element with a `white-box` class for consistent styling.Created a new install.astro page with detailed installation instructions for multiple platforms. Updated index.astro to link to the new install page instead of installation.astro. Renamed installation.astro to usage.astro and updated its content to focus on usage. Improved 404.astro layout with a main container.