### PR TITLE
Add symbol visibility flags to OBS vcpkg triplets

### DIFF
--- a/vcpkg-triplets/arm64-osx-obs.cmake
+++ b/vcpkg-triplets/arm64-osx-obs.cmake
@@ -6,3 +6,5 @@ set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES arm64)
 
 set(VCPKG_OSX_DEPLOYMENT_TARGET "12.0")
+set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -fvisibility=hidden")
+set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines-hidden")

--- a/vcpkg-triplets/x64-linux-obs.cmake
+++ b/vcpkg-triplets/x64-linux-obs.cmake
@@ -4,5 +4,5 @@ set(VCPKG_LIBRARY_LINKAGE static)
 
 set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 
-set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -mavx2")
-set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -mavx2")
+set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -mavx2 -fvisibility=hidden")
+set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -mavx2 -fvisibility=hidden -fvisibility-inlines-hidden")

--- a/vcpkg-triplets/x64-osx-obs.cmake
+++ b/vcpkg-triplets/x64-osx-obs.cmake
@@ -6,5 +6,5 @@ set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
 set(VCPKG_OSX_ARCHITECTURES x86_64)
 
 set(VCPKG_OSX_DEPLOYMENT_TARGET "12.0")
-set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -mavx2")
-set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -mavx2")
+set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -mavx2 -fvisibility=hidden")
+set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -mavx2 -fvisibility=hidden -fvisibility-inlines-hidden")


### PR DESCRIPTION
This pull request updates the compiler flags in several vcpkg triplet files to improve symbol visibility and optimize binary size and security. The main change is the addition of flags to hide symbols by default, which helps prevent symbol clashes and reduces exported symbols in the resulting binaries.

Compiler flag updates for symbol visibility:

* Added `-fvisibility=hidden` to both C and C++ compiler flags, and `-fvisibility-inlines-hidden` to C++ flags in the following triplet files:
  - `vcpkg-triplets/arm64-osx-obs.cmake`
  - `vcpkg-triplets/x64-osx-obs.cmake`
  - `vcpkg-triplets/x64-linux-obs.cmake`Appended '-fvisibility=hidden' and '-fvisibility-inlines-hidden' to C and C++ flags in arm64-osx-obs, x64-linux-obs, and x64-osx-obs triplets to improve symbol visibility control and reduce exported symbols in builds.