### PR TITLE
chore: Bump version to 2.7.1

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -38,7 +38,7 @@
   },
   "name": "live-backgroundremoval-lite",
   "displayName": "Live Background Removal Lite",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "author": "Kaito Udagawa",
   "website": "https://kaito-tokyo.github.io/live-backgroundremoval-lite/",
   "email": "umireon@kaito.tokyo"


### PR DESCRIPTION
This pull request includes a minor version bump for the project, updating the version number in the `buildspec.json` file from 2.7.0 to 2.7.1.