### PR TITLE
Update build-project.yaml

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -477,12 +477,6 @@ jobs:
           config: ${{ needs.check-event.outputs.config }}
           package: ${{ fromJSON(needs.check-event.outputs.package) }}
 
-      - name: Upload Source Tarball 🗜️
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-${{ matrix.os }}-sources-${{ needs.check-event.outputs.commitHash }}
-          path: ${{ github.workspace }}/release/${{ steps.setup.outputs.pluginName }}-${{ steps.setup.outputs.pluginVersion }}-source.*
-
       - name: Upload Artifacts 📡
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This pull request makes a small change to the build workflow by removing the step that uploads the source tarball as an artifact. The rest of the artifact upload process remains unchanged.

- Removed the "Upload Source Tarball" step from the `.github/workflows/build-project.yaml` workflow, so source tarballs will no longer be uploaded as build artifacts.