### PR TITLE
chore: Update PKGBUILD and Flatpak for 2.8.0

### DIFF
--- a/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
+++ b/unsupported/arch/live-backgroundremoval-lite/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Kaito Udagawa <umireon at kaito dot tokyo>
 pkgname=live-backgroundremoval-lite
-pkgver=2.7.1
+pkgver=2.8.0
 pkgrel=1
 pkgdesc='Live Background Removal Lite for OBS Studio'
 arch=('x86_64')
@@ -10,7 +10,7 @@ depends=('obs-studio' 'curl' 'fmt' 'ncnn' 'opencv')
 makedepends=('git' 'cmake' 'ninja')
 conflicts=("${pkgname}-git" "${pkgname}-git-debug")
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/kaito-tokyo/$pkgname/archive/refs/tags/$pkgver.tar.gz")
-sha256sums=('3222013639359a38935716be6a6a4910e58664e71b4fa585034a7af292261711')
+sha256sums=('f903b62e0ae5a11d6e84214e2f1bcccc881ee757b5211af0a768dd80bae50c14')
 
 build() {
   cd "${pkgname}-${pkgver}"

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.json
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.json
@@ -46,8 +46,8 @@
         {
           "type": "git",
           "url": "https://github.com/kaito-tokyo/live-backgroundremoval-lite.git",
-          "tag": "2.7.1",
-          "commit": "060149be19b7d5fc409242d221dfa00b9d6bc505",
+          "tag": "2.8.0",
+          "commit": "66dd000186d9316fd4ea0b960457e613fd666649",
           "x-checker-data": {
             "type": "git",
             "tag-pattern": "^([\\d.]+)$"

--- a/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
+++ b/unsupported/flatpak/com.obsproject.Studio.Plugin.LiveBackgroundRemovalLite.metainfo.xml
@@ -20,6 +20,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <releases>
+    <release version="2.8.0" date="2025-12-13"/>
     <release version="2.7.1" date="2025-12-11"/>
     <release version="2.7.0" date="2025-12-11"/>
     <release version="2.6.0" date="2025-11-24"/>


### PR DESCRIPTION
This pull request updates the Live Background Removal Lite plugin for OBS Studio to version 2.8.0 across both the Arch Linux and Flatpak packaging files. The changes ensure that users will receive the latest version of the plugin with the correct source and integrity checks.

**Arch Linux packaging updates:**
* Bumped the `pkgver` in `PKGBUILD` from `2.7.1` to `2.8.0`, and updated the `sha256sums` to match the new release archive. [[1]](diffhunk://#diff-83756e3d4361f41f9db1d048bf05d7c41aae46b964eafa44318c2a062058d7fbL3-R3) [[2]](diffhunk://#diff-83756e3d4361f41f9db1d048bf05d7c41aae46b964eafa44318c2a062058d7fbL13-R13)

**Flatpak packaging updates:**
* Updated the Flatpak manifest to use tag and commit for version `2.8.0` of `live-backgroundremoval-lite`.
* Added a new release entry for version `2.8.0` in the Flatpak metainfo XML.