### PR TITLE
Highlight latest release in version page

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,8 +3,6 @@ name: Deploy Docs
 on:
   push:
     branches: [main]
-  release:
-    types: [published, edited]
   workflow_dispatch:
 
 concurrency:

--- a/docs/src/pages/versions/[version].astro
+++ b/docs/src/pages/versions/[version].astro
@@ -17,6 +17,9 @@ interface Props {
   release: Awaited<
     ReturnType<Octokit["rest"]["repos"]["getReleaseByTag"]>
   >["data"];
+  latestRelease: Awaited<
+    ReturnType<Octokit["rest"]["repos"]["getLatestRelease"]>
+  >["data"];
 }
 
 export async function getStaticPaths(
@@ -30,9 +33,14 @@ export async function getStaticPaths(
     per_page: 100,
   });
 
+  const latestRelease = await octokit.rest.repos.getLatestRelease({
+    owner: GITHUB_OWNER,
+    repo: GITHUB_REPO,
+  });
+
   return allReleases.map((release) => ({
     params: { version: release.tag_name },
-    props: { release },
+    props: { release, latestRelease: latestRelease.data },
   }));
 }
 
@@ -51,7 +59,7 @@ function stripMarkdown(markdown: string): string {
     .trim();
 }
 
-const { release } = Astro.props;
+const { release, latestRelease } = Astro.props;
 
 const windowsZipAsset = release.assets.find((a) =>
   a.name.endsWith("windows-x64.zip"),
@@ -173,7 +181,14 @@ const schemaData = {
   <main class="white-box">
     <article>
       <hgroup class="version-header">
-        <h1>Version {release.tag_name}</h1>
+        <div class="version-title-row">
+          <h1>Version {release.tag_name}</h1>
+          {
+            release.id === latestRelease.id && (
+              <span class="badge-latest">Latest</span>
+            )
+          }
+        </div>
         <h2>Live Background Removal Lite</h2>
       </hgroup>
 
@@ -313,6 +328,29 @@ const schemaData = {
 </Layout>
 
 <style>
+  .version-title-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .version-title-row h1 {
+    margin: 0;
+  }
+
+  .badge-latest {
+    display: inline-block;
+    padding: 0.25rem 0.6rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    line-height: 1;
+    color: #ffffff;
+    background-color: var(--color-download-button-bg);
+    border-radius: 2em;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
   .alert-box {
     background-color: var(--color-alert-bg);
     color: var(--color-alert-fg);
@@ -321,7 +359,7 @@ const schemaData = {
   }
 
   dt {
-    font-weight: bold;
+    font-weight: 600;
   }
 
   dt,


### PR DESCRIPTION
This pull request updates the documentation site to visually mark the latest release on versioned documentation pages. It fetches the latest release data from GitHub, passes it to the version page, and displays a "Latest" badge next to the version title if the current page corresponds to the most recent release. Additionally, it removes release-triggered deploys from the docs deployment workflow and makes minor style improvements.

**Docs site improvements:**

* The version page now fetches both the specific release and the latest release from GitHub and passes them as props, enabling comparison between the two. (`docs/src/pages/versions/[version].astro`) ([docs/src/pages/versions/[version].astroR20-R22](diffhunk://#diff-80751f43db1d42fd94a645eada46e5c22603971bb2525caeb437f39b80c5eddaR20-R22), [docs/src/pages/versions/[version].astroR36-R43](diffhunk://#diff-80751f43db1d42fd94a645eada46e5c22603971bb2525caeb437f39b80c5eddaR36-R43), [docs/src/pages/versions/[version].astroL54-R62](diffhunk://#diff-80751f43db1d42fd94a645eada46e5c22603971bb2525caeb437f39b80c5eddaL54-R62))
* If the version page is rendering the latest release, a "Latest" badge is displayed next to the version title for clear identification. (`docs/src/pages/versions/[version].astro`) ([docs/src/pages/versions/[version].astroR184-R191](diffhunk://#diff-80751f43db1d42fd94a645eada46e5c22603971bb2525caeb437f39b80c5eddaR184-R191))
* Added styling for the "Latest" badge and improved layout of the version title row. (`docs/src/pages/versions/[version].astro`) ([docs/src/pages/versions/[version].astroR331-R353](diffhunk://#diff-80751f43db1d42fd94a645eada46e5c22603971bb2525caeb437f39b80c5eddaR331-R353))
* Minor style tweak: increased the font weight of `<dt>` elements for better readability. (`docs/src/pages/versions/[version].astro`) ([docs/src/pages/versions/[version].astroL324-R362](diffhunk://#diff-80751f43db1d42fd94a645eada46e5c22603971bb2525caeb437f39b80c5eddaL324-R362))

**CI/CD workflow change:**

* The docs deployment workflow no longer triggers on release events; it now only runs on pushes to `main` or manual dispatches. (`.github/workflows/deploy-docs.yml`)Adds a 'Latest' badge to the version page when viewing the most recent release. Updates the Astro page to fetch the latest release and passes it to the component, along with related style adjustments. Also removes the release trigger from the deploy-docs GitHub workflow.