### PR TITLE
Improve video and code block styling on docs pages

### DIFF
--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -341,6 +341,10 @@ const structuredData = {
       flex-direction: column;
       align-items: center;
     }
+    .demo-container video {
+      max-width: 100%;
+      height: auto;
+    }
     .demo-image {
       border: 1px solid #ccc;
       border-radius: 8px;

--- a/docs/src/pages/versions/[version].astro
+++ b/docs/src/pages/versions/[version].astro
@@ -362,9 +362,9 @@ const schemaData = {
     font-weight: 600;
   }
 
-  dt,
-  dd {
-    overflow: hidden;
+  dd code {
+    word-break: break-all;
+    white-space: pre-wrap;
   }
 
   .release-notes pre {


### PR DESCRIPTION
This pull request introduces minor improvements to the documentation site's styling, focusing on better media display and improved formatting for code snippets within definition descriptions.

Styling improvements:

* Ensured that videos within the `.demo-container` class are responsive by setting their `max-width` to 100% and `height` to auto in `index.astro`.
* Improved the display of code snippets inside `dd` elements by enabling word breaking and pre-wrapping, making long code examples more readable in `versions/[version].astro`. ([docs/src/pages/versions/[version].astroL365-R367](diffhunk://#diff-80751f43db1d42fd94a645eada46e5c22603971bb2525caeb437f39b80c5eddaL365-R367))Added responsive styling for videos in the demo container on the index page. Updated code block styles in versioned docs to improve word breaking and wrapping for better readability.