### PR TITLE
Update deploy-docs.yml

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,6 +24,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     permissions:
+      attestations: write
       contents: read
       id-token: write
       pages: write


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow permissions for documentation deployment. The change grants write access to the `attestations` permission, which may be needed for future security or verification steps.