### PR TITLE
Update copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,6 @@
 - For empty argument lists, use `()` instead of `(void)`, except within regions marked by `extern "C"`.
 - After modifying C or C++ files, format them with `clang-format-19`.
 - After modifying CMake files, format them with `gersemi`.
-- The OBS team maintains CMake and GitHub Actions files. Do not modify these, except for workflow files starting with `my-`.
 - The default branch is `main`.
 - Ensure each file ends with a single empty newline. Builds will fail if this rule is not followed.
 - Member variables must be suffixed with an underscore (`_`).


### PR DESCRIPTION
This pull request makes a minor update to the `.github/copilot-instructions.md` documentation, clarifying team ownership of certain files.

* Removed the statement that the OBS team maintains CMake and GitHub Actions files, except for workflow files starting with `my-`.