### PR TITLE
Update FileVerifierDropArea.ts

### DIFF
--- a/docs/src/components/FileVerifierDropArea.ts
+++ b/docs/src/components/FileVerifierDropArea.ts
@@ -81,7 +81,6 @@ customElements.define(
           if (!e.dataTransfer) return;
           for (const file of e.dataTransfer.files) {
             try {
-              throw new Error("Test error"); // --- IGNORE ---
               const buffer = await file.arrayBuffer();
               const sha256Buffer = await crypto.subtle.digest(
                 "SHA-256",


### PR DESCRIPTION
This pull request removes a line of test code that was throwing an error in the file drop handler. This change ensures that file processing will proceed as intended without being interrupted by the test error.

* Removed a test error throw statement from the file drop event handler in `FileVerifierDropArea.ts`, allowing files to be processed normally.