### PR TITLE
Add Fedora instructions and links to docs

### DIFF
--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -159,17 +159,20 @@ const structuredData = {
         <li>
           <a
             href="https://github.com/kaito-tokyo/live-backgroundremoval-lite/tree/main/unsupported/arch"
+            >Arch Linux</a
           >
-            Arch Linux
-          </a>
         </li>
-
         <li>
           <a
             href="https://github.com/kaito-tokyo/live-backgroundremoval-lite/tree/main/unsupported/flatpak"
+            >Flatpak</a
           >
-            Flatpak
-          </a>
+        </li>
+        <li>
+          <a
+            href="https://github.com/kaito-tokyo/live-backgroundremoval-lite/tree/main/unsupported/fedora"
+            >Fedora</a
+          >
         </li>
       </ul>
 

--- a/docs/src/pages/versions/[version].astro
+++ b/docs/src/pages/versions/[version].astro
@@ -252,17 +252,20 @@ const schemaData = {
           <li>
             <a
               href="https://github.com/kaito-tokyo/live-backgroundremoval-lite/tree/main/unsupported/arch"
+              >Arch Linux (Latest)</a
             >
-              Arch Linux (Latest)
-            </a>
           </li>
-
           <li>
             <a
               href="https://github.com/kaito-tokyo/live-backgroundremoval-lite/tree/main/unsupported/flatpak"
+              >Flatpak (Latest)</a
             >
-              Flatpak (Latest)
-            </a>
+          </li>
+          <li>
+            <a
+              href="https://github.com/kaito-tokyo/live-backgroundremoval-lite/tree/main/unsupported/fedora"
+              >Fedora (Latest)</a
+            >
           </li>
         </ul>
       </section>

--- a/unsupported/fedora/README.md
+++ b/unsupported/fedora/README.md
@@ -1,10 +1,12 @@
-# Building and Installing on Fedora
+# Unsupported Build Instructions for Fedora
 
 ## ⚠️ Important Notice: Manual Build Required
 
-This plugin is not available as a pre-built package for Fedora. Users will need to build and install the plugin from source.
+This plugin is **not officially available as a pre-built package for Fedora**. Users will need to build and install the plugin from source using the instructions provided below.
 
-## Building from Source
+## Building from This Repository (Manual Installation)
+
+If you wish to proceed with building the plugin from these local files, you will need the standard Fedora build tools.
 
 ### Prerequisites
 
@@ -16,39 +18,39 @@ sudo dnf install @development-tools ninja-build rpm-build obs-studio-devel qt6-q
 
 ### Build and Install Steps
 
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/kaito-tokyo/live-backgroundremoval-lite.git
-   cd live-backgroundremoval-lite
-   ```
+1.  Clone the repository:
+    ```bash
+    git clone https://github.com/kaito-tokyo/live-backgroundremoval-lite.git
+    cd live-backgroundremoval-lite
+    ```
 
-2. Configure the project:
-   ```bash
-   cmake \
-    -B build -S . \
-    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-    -DCMAKE_INSTALL_PREFIX=/usr \
-    -DUSE_PKGCONFIG=ON \
-    -DBUILD_TESTING=OFF \
-    -GNinja
-   ```
+2.  Configure the project:
+    ```bash
+    cmake \
+     -B build -S . \
+     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+     -DCMAKE_INSTALL_PREFIX=/usr \
+     -DUSE_PKGCONFIG=ON \
+     -DBUILD_TESTING=OFF \
+     -GNinja
+    ```
 
-3. Build the project:
-   ```bash
-   cmake --build build
-   ```
+3.  Build the project:
+    ```bash
+    cmake --build build
+    ```
 
-4. Package the plugin:
-   ```bash
-   cpack --config build/CPackConfig.cmake -G RPM
-   ```
+4.  Package the plugin:
+    ```bash
+    cpack --config build/CPackConfig.cmake -G RPM
+    ```
 
-5. Install the plugin:
-   ```bash
-   sudo dnf install release/*.rpm
-   ```
+5.  Install the plugin:
+    ```bash
+    sudo dnf install release/*.rpm
+    ```
 
-6. Restart OBS Studio to load the plugin.
+6.  Restart OBS Studio to load the plugin.
 
 ## Verifying the Installation
 


### PR DESCRIPTION
This pull request improves the documentation for unsupported platforms by adding Fedora as a listed option alongside Arch Linux and Flatpak, and updates the Fedora build instructions for clarity. The most important changes are:

**Documentation Updates:**

* Added Fedora as an unsupported platform in the installation links on both the main index page (`index.astro`) and the version-specific page (`[version].astro`), ensuring Fedora users can easily find relevant build instructions. ([docs/src/pages/index.astroR162-L172](diffhunk://#diff-c7ed1fae6e40bd1e7ece8c4677f63529f7a5230ca3a5636c5e096f493e0da13aR162-L172), [docs/src/pages/versions/[version].astroR255-L265](diffhunk://#diff-80751f43db1d42fd94a645eada46e5c22603971bb2525caeb437f39b80c5eddaR255-L265))

**Fedora Build Instructions:**

* Updated `unsupported/fedora/README.md` to clarify the unsupported status, emphasize manual build requirements, and improve the section on building from the repository for Fedora users.Added Fedora to the list of unsupported platforms in the main and versioned documentation pages, including links to the Fedora-specific instructions. Updated the Fedora README with clearer build and installation steps, improved formatting, and clarified manual build requirements.