### PR TITLE
Add GitHub build metadata to layout

### DIFF
--- a/docs/src/layouts/Layout.astro
+++ b/docs/src/layouts/Layout.astro
@@ -1,6 +1,9 @@
 ---
 import { joinURL } from "ufo";
+import { GITHUB_OWNER, GITHUB_REPO } from "../lib/info";
 import "../styles/global.css";
+
+const { BASE_URL, GITHUB_SHA, GITHUB_RUN_ID } = import.meta.env;
 
 interface Props {
   lang: string;
@@ -17,7 +20,10 @@ const {
   additionalCspScriptSrc,
   trustedTypes,
 } = Astro.props;
-const { BASE_URL } = import.meta.env;
+
+const revision = GITHUB_SHA ?? "undefined";
+const shortRevision = GITHUB_SHA?.substring(0, 7) ?? "undefined";
+const runId = GITHUB_RUN_ID ?? "undefined";
 ---
 
 <!doctype html>
@@ -81,6 +87,10 @@ const { BASE_URL } = import.meta.env;
     />
     <link rel="manifest" href={joinURL(BASE_URL, "site.webmanifest")} />
 
+    <meta name="revision" content={revision} />
+    <meta name="github-repo" content={`${GITHUB_OWNER}/${GITHUB_REPO}`} />
+    <meta name="github-build-id" content={runId} />
+
     <slot name="head-bottom" />
   </head>
   <body>
@@ -103,6 +113,7 @@ const { BASE_URL } = import.meta.env;
             rel="noopener noreferrer">llms.txt</a
           >
         </div>
+        <div>Commit: <a href={`https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/commit/${GITHUB_SHA}`} target="_blank" rel="noopener noreferrer">{shortRevision}</a></div>
         <div>&copy; 2025 Kaito Udagawa</div>
       </footer>
     </div>


### PR DESCRIPTION
This pull request updates the `Layout.astro` file to enhance build metadata visibility and provide more information about the documentation's source and version. The main changes are the addition of GitHub-related metadata and commit information to both the HTML `<head>` and the page footer.

**Build and metadata enhancements:**

* Added new meta tags to the HTML `<head>` for revision, GitHub repository, and build ID, using `GITHUB_SHA`, `GITHUB_OWNER`, `GITHUB_REPO`, and `GITHUB_RUN_ID` environment variables.
* Imported `GITHUB_OWNER` and `GITHUB_REPO` from the local info module and destructured additional environment variables for use in the layout. [[1]](diffhunk://#diff-544d55074ae7e443bdb0dd0bacadb39b7f5d51a41b27bcf6381f8b0616038ce0R3-R7) [[2]](diffhunk://#diff-544d55074ae7e443bdb0dd0bacadb39b7f5d51a41b27bcf6381f8b0616038ce0L20-R26)

**Footer improvements:**

* Displayed the current commit short SHA as a link to the corresponding commit on GitHub in the page footer.Injected GitHub commit SHA, repo info, and build ID as meta tags in the document head. Also added a footer link to the current commit for improved traceability.