### PR TITLE
Improve commit hash link

### DIFF
--- a/docs/src/layouts/Layout.astro
+++ b/docs/src/layouts/Layout.astro
@@ -24,6 +24,7 @@ const {
 const isValidSha = GITHUB_SHA && GITHUB_SHA.trim() !== "";
 const revision = isValidSha ? GITHUB_SHA : "undefined";
 const shortRevision = isValidSha ? GITHUB_SHA.substring(0, 7) : "undefined";
+const runId = GITHUB_RUN_ID ?? "undefined";
 ---
 
 <!doctype html>


### PR DESCRIPTION
This pull request makes a minor update to the commit link in the site footer to ensure it only generates a valid GitHub commit URL when the `revision` is defined. If `revision` is `'undefined'`, the link now points to `#` instead of an invalid URL.