### PR TITLE
More Strict Site Verification

### DIFF
--- a/docs/src/pages/site-verification.md
+++ b/docs/src/pages/site-verification.md
@@ -99,8 +99,8 @@ You can manually verify the website's integrity using the GitHub CLI.
 #### 1. Download Provenance Files
 
 ```bash
-curl -fsSL -O "https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.json"
-curl -fsSL -O "https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.attestation.jsonl"
+curl -fsS -O "https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.json"
+curl -fsS -O "https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.attestation.jsonl"
 ```
 
 #### 2. Verify Attestation
@@ -120,6 +120,7 @@ gh attestation verify provenance.json \
 Download all files listed in the provenance:
 
 ```bash
+rm -rf site
 mkdir -p site
 jq -r --arg base "https://kaito-tokyo.github.io/live-backgroundremoval-lite/" '
   .subject[] |
@@ -128,7 +129,7 @@ jq -r --arg base "https://kaito-tokyo.github.io/live-backgroundremoval-lite/" '
   "url = \"\($url)\"",
   "output = \"site/\($path)\"",
   "create-dirs"
-' provenance.json | curl -fsS -K -
+' provenance.json | curl -f -K -
 ```
 
 #### 4. Generate Checksums
@@ -162,8 +163,8 @@ Here's a complete script that performs all verification steps:
 set -euo pipefail
 
 echo "==> Downloading provenance files..."
-curl -fsSL -O "https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.json"
-curl -fsSL -O "https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.attestation.jsonl"
+curl -fsS -O "https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.json"
+curl -fsS -O "https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.attestation.jsonl"
 
 echo "==> Verifying attestation..."
 gh attestation verify provenance.json \
@@ -180,7 +181,7 @@ jq -r --arg base "https://kaito-tokyo.github.io/live-backgroundremoval-lite/" '
   "url = \"\($url)\"",
   "output = \"site/\($path)\"",
   "create-dirs"
-' provenance.json | curl -fsS -K -
+' provenance.json | curl -f -K -
 
 echo "==> Generating checksums..."
 jq -r --arg base "https://kaito-tokyo.github.io/live-backgroundremoval-lite/" '
@@ -365,16 +366,16 @@ To verify the website yourself, you can use the following one-liner (requires ba
 
 ```bash
 gh attestation verify \
-  <(curl -fsSL https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.json) \
+  <(curl -fsS https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.json) \
   --repo kaito-tokyo/live-backgroundremoval-lite \
-  --bundle <(curl -fsSL https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.attestation.jsonl)
+  --bundle <(curl -fsS https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.attestation.jsonl)
 ```
 
 Or download the files first (shell-agnostic approach):
 
 ```bash
-curl -fsSL -O "https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.json"
-curl -fsSL -O "https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.attestation.jsonl"
+curl -fsS -O "https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.json"
+curl -fsS -O "https://kaito-tokyo.github.io/live-backgroundremoval-lite/provenance.attestation.jsonl"
 gh attestation verify provenance.json --repo kaito-tokyo/live-backgroundremoval-lite --bundle provenance.attestation.jsonl
 ```
 


### PR DESCRIPTION
This pull request makes minor improvements to the site verification documentation by updating the `curl` command options for consistency and reliability, and by ensuring the download directory is cleaned before use.

- **Command Consistency and Reliability:**
  * Changed `curl -fsSL` to `curl -fsS` in all relevant commands to streamline options and improve error reporting. [[1]](diffhunk://#diff-0f3714332a02f401ac5f5cd9af35bad3c66b062a5e95ed02ad937b631a5fb110L102-R103) [[2]](diffhunk://#diff-0f3714332a02f401ac5f5cd9af35bad3c66b062a5e95ed02ad937b631a5fb110L165-R167) [[3]](diffhunk://#diff-0f3714332a02f401ac5f5cd9af35bad3c66b062a5e95ed02ad937b631a5fb110L368-R378)
  * Removed the `-L` option from `curl` commands where it was unnecessary, and removed the `-sS` flags from a `curl` command used with `-K -` to avoid redundant silent output. [[1]](diffhunk://#diff-0f3714332a02f401ac5f5cd9af35bad3c66b062a5e95ed02ad937b631a5fb110L131-R132) [[2]](diffhunk://#diff-0f3714332a02f401ac5f5cd9af35bad3c66b062a5e95ed02ad937b631a5fb110L183-R184)

- **Script Safety:**
  * Added `rm -rf site` before creating the `site` directory to ensure a clean state before downloading files.