### PR TITLE
Refactor core to LiveBackgroundRemovalLite/Filter and update namespaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,8 +99,8 @@ endif()
 add_subdirectory(src)
 
 add_library(${CMAKE_PROJECT_NAME} MODULE)
-target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_PROJECT_NAME}_Core)
-target_sources(${CMAKE_PROJECT_NAME} PRIVATE src/plugin-main.c)
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_PROJECT_NAME}_Filter OBS::libobs)
+target_sources(${CMAKE_PROJECT_NAME} PRIVATE src/plugin-main.cpp)
 target_compile_options(
   ${CMAKE_PROJECT_NAME}
   PRIVATE $<$<C_COMPILER_ID:Clang,AppleClang>:-Wno-quoted-include-in-framework-header -Wno-comma>

--- a/src/BridgeUtils/AsyncTextureReader.hpp
+++ b/src/BridgeUtils/AsyncTextureReader.hpp
@@ -26,8 +26,7 @@
 
 #include "GsUnique.hpp"
 
-namespace KaitoTokyo {
-namespace BridgeUtils {
+namespace KaitoTokyo::BridgeUtils {
 
 /**
  * @brief Internal implementation details for AsyncTextureReader.
@@ -344,5 +343,4 @@ private:
 	std::mutex gpuMutex_;
 };
 
-} // namespace BridgeUtils
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::BridgeUtils

--- a/src/BridgeUtils/GsUnique.hpp
+++ b/src/BridgeUtils/GsUnique.hpp
@@ -25,8 +25,7 @@
 
 #include "ObsUnique.hpp"
 
-namespace KaitoTokyo {
-namespace BridgeUtils {
+namespace KaitoTokyo::BridgeUtils {
 
 /**
  * @brief Internal helpers for managing Graphics Suite (GS) resources
@@ -251,5 +250,4 @@ inline unique_gs_stagesurf_t make_unique_gs_stagesurf(std::uint32_t width, std::
 	return unique_gs_stagesurf_t(rawSurface);
 }
 
-} // namespace BridgeUtils
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::BridgeUtils

--- a/src/BridgeUtils/ObsLogger.hpp
+++ b/src/BridgeUtils/ObsLogger.hpp
@@ -22,8 +22,7 @@
 
 #include <ILogger.hpp>
 
-namespace KaitoTokyo {
-namespace BridgeUtils {
+namespace KaitoTokyo::BridgeUtils {
 
 class ObsLogger final : public Logger::ILogger {
 public:
@@ -74,5 +73,4 @@ private:
 	mutable std::mutex mutex_;
 };
 
-} // namespace BridgeUtils
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::BridgeUtils

--- a/src/BridgeUtils/ObsUnique.hpp
+++ b/src/BridgeUtils/ObsUnique.hpp
@@ -20,8 +20,7 @@
 
 #include <obs-module.h>
 
-namespace KaitoTokyo {
-namespace BridgeUtils {
+namespace KaitoTokyo::BridgeUtils {
 
 /**
  * @brief Contains custom deleters for managing OBS-specific resource pointers
@@ -137,5 +136,4 @@ inline unique_bfree_char_t unique_obs_module_config_path(const char *file)
 	return unique_bfree_char_t(rawPath);
 }
 
-} // namespace BridgeUtils
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::BridgeUtils

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,4 +9,4 @@ add_subdirectory(BridgeUtils)
 
 add_subdirectory(SelfieSegmenter)
 
-add_subdirectory(Core)
+add_subdirectory(LiveBackgroundRemovalLite)

--- a/src/LiveBackgroundRemovalLite/CMakeLists.txt
+++ b/src/LiveBackgroundRemovalLite/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Filter)

--- a/src/LiveBackgroundRemovalLite/Filter/CMakeLists.txt
+++ b/src/LiveBackgroundRemovalLite/Filter/CMakeLists.txt
@@ -1,10 +1,11 @@
-add_library(${CMAKE_PROJECT_NAME}_Core STATIC)
+add_library(${CMAKE_PROJECT_NAME}_Filter STATIC)
+target_include_directories(${CMAKE_PROJECT_NAME}_Filter PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(
-  ${CMAKE_PROJECT_NAME}_Core
+  ${CMAKE_PROJECT_NAME}_Filter
   PUBLIC OBS::libobs OBS::obs-frontend-api Qt6::Core Qt6::Widgets BridgeUtils SelfieSegmenter UpdateChecker TaskQueue
 )
 target_sources(
-  ${CMAKE_PROJECT_NAME}_Core
+  ${CMAKE_PROJECT_NAME}_Filter
   PRIVATE
     DebugWindow.cpp
     DebugWindow.hpp
@@ -18,10 +19,10 @@ target_sources(
     RenderingContext.hpp
 )
 target_compile_options(
-  ${CMAKE_PROJECT_NAME}_Core
+  ${CMAKE_PROJECT_NAME}_Filter
   PRIVATE $<$<C_COMPILER_ID:Clang,AppleClang>:-Wno-quoted-include-in-framework-header -Wno-comma>
 )
 set_target_properties(
-  ${CMAKE_PROJECT_NAME}_Core
+  ${CMAKE_PROJECT_NAME}_Filter
   PROPERTIES AUTOMOC ON AUTOUIC ON AUTORCC ON
 )

--- a/src/LiveBackgroundRemovalLite/Filter/DebugWindow.cpp
+++ b/src/LiveBackgroundRemovalLite/Filter/DebugWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Live Background Removal Lite
+ * Live Background Removal Lite - Filter Module
  * Copyright (C) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This program is free software; you can redistribute it and/or modify
@@ -85,8 +85,7 @@ const std::vector<const char *> r32fSubTextures = {
 
 } // namespace
 
-namespace KaitoTokyo {
-namespace LiveBackgroundRemovalLite {
+namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter {
 
 DebugWindow::DebugWindow(std::weak_ptr<MainPluginContext> weakMainPluginContext, QWidget *parent)
 	: QDialog(parent),
@@ -413,5 +412,4 @@ void DebugWindow::onTextureSelectionChanged(int index)
 	selectedPreviewTextureIndex_.store(index, std::memory_order_release);
 }
 
-} // namespace LiveBackgroundRemovalLite
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter

--- a/src/LiveBackgroundRemovalLite/Filter/DebugWindow.hpp
+++ b/src/LiveBackgroundRemovalLite/Filter/DebugWindow.hpp
@@ -1,5 +1,5 @@
 /*
- * Live Background Removal Lite
+ * Live Background Removal Lite - Filter Module
  * Copyright (C) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This program is free software; you can redistribute it and/or modify
@@ -25,8 +25,7 @@
 
 #include <AsyncTextureReader.hpp>
 
-namespace KaitoTokyo {
-namespace LiveBackgroundRemovalLite {
+namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter {
 
 class MainPluginContext;
 
@@ -69,5 +68,4 @@ private:
 	std::vector<std::uint8_t> bufferSubPaddedR8_;
 };
 
-} // namespace LiveBackgroundRemovalLite
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter

--- a/src/LiveBackgroundRemovalLite/Filter/MainEffect.hpp
+++ b/src/LiveBackgroundRemovalLite/Filter/MainEffect.hpp
@@ -1,5 +1,5 @@
 /*
- * Live Background Removal Lite
+ * Live Background Removal Lite - Filter Module
  * Copyright (C) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This program is free software; you can redistribute it and/or modify
@@ -23,8 +23,7 @@
 #include <GsUnique.hpp>
 #include <ObsUnique.hpp>
 
-namespace KaitoTokyo {
-namespace LiveBackgroundRemovalLite {
+namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter {
 
 struct TransformStateGuard {
 	TransformStateGuard()
@@ -433,5 +432,4 @@ public:
 	gs_eparam_t *const floatAlpha_ = nullptr;
 };
 
-} // namespace LiveBackgroundRemovalLite
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter

--- a/src/LiveBackgroundRemovalLite/Filter/MainPluginContext.cpp
+++ b/src/LiveBackgroundRemovalLite/Filter/MainPluginContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Live Background Removal Lite
+ * Live Background Removal Lite - Filter Module
  * Copyright (C) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This program is free software; you can redistribute it and/or modify
@@ -33,8 +33,7 @@
 using namespace KaitoTokyo::Logger;
 using namespace KaitoTokyo::BridgeUtils;
 
-namespace KaitoTokyo {
-namespace LiveBackgroundRemovalLite {
+namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter {
 
 MainPluginContext::MainPluginContext(obs_data_t *settings, obs_source_t *source,
 				     std::shared_future<std::string> latestVersionFuture, const ILogger &logger)
@@ -396,5 +395,4 @@ std::shared_ptr<RenderingContext> MainPluginContext::createRenderingContext(std:
 	return renderingContext;
 }
 
-} // namespace LiveBackgroundRemovalLite
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter

--- a/src/LiveBackgroundRemovalLite/Filter/MainPluginContext.h
+++ b/src/LiveBackgroundRemovalLite/Filter/MainPluginContext.h
@@ -1,5 +1,5 @@
 /*
- * Live Background Removal Lite
+ * Live Background Removal Lite - Filter Module
  * Copyright (C) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This program is free software; you can redistribute it and/or modify
@@ -32,8 +32,7 @@
 #include "PluginProperty.hpp"
 #include "MainEffect.hpp"
 
-namespace KaitoTokyo {
-namespace LiveBackgroundRemovalLite {
+namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter {
 
 class DebugWindow;
 class RenderingContext;
@@ -90,8 +89,7 @@ private:
 	mutable std::mutex debugWindowMutex_;
 };
 
-} // namespace LiveBackgroundRemovalLite
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter
 
 extern "C" {
 #endif // __cplusplus

--- a/src/LiveBackgroundRemovalLite/Filter/MainPluginContext_c.cpp
+++ b/src/LiveBackgroundRemovalLite/Filter/MainPluginContext_c.cpp
@@ -1,5 +1,5 @@
 /*
- * Live Background Removal Lite
+ * Live Background Removal Lite - Filter Module
  * Copyright (C) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This program is free software; you can redistribute it and/or modify
@@ -30,7 +30,7 @@
 
 using namespace KaitoTokyo::Logger;
 using namespace KaitoTokyo::BridgeUtils;
-using namespace KaitoTokyo::LiveBackgroundRemovalLite;
+using namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter;
 
 namespace {
 

--- a/src/LiveBackgroundRemovalLite/Filter/PluginConfig.hpp
+++ b/src/LiveBackgroundRemovalLite/Filter/PluginConfig.hpp
@@ -1,5 +1,5 @@
 /*
- * Live Background Removal Lite
+ * Live Background Removal Lite - Filter Module
  * Copyright (C) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This program is free software; you can redistribute it and/or modify
@@ -20,8 +20,7 @@
 
 #include <ObsUnique.hpp>
 
-namespace KaitoTokyo {
-namespace LiveBackgroundRemovalLite {
+namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter {
 
 struct PluginConfig {
 	std::string latestVersionURL =
@@ -75,5 +74,4 @@ struct PluginConfig {
 	}
 };
 
-} // namespace LiveBackgroundRemovalLite
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter

--- a/src/LiveBackgroundRemovalLite/Filter/PluginProperty.hpp
+++ b/src/LiveBackgroundRemovalLite/Filter/PluginProperty.hpp
@@ -1,5 +1,5 @@
 /*
- * Live Background Removal Lite
+ * Live Background Removal Lite - Filter Module
  * Copyright (C) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This program is free software; you can redistribute it and/or modify
@@ -14,8 +14,7 @@
 
 #pragma once
 
-namespace KaitoTokyo {
-namespace LiveBackgroundRemovalLite {
+namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter {
 
 enum class FilterLevel : int {
 	Default = 0,
@@ -43,5 +42,4 @@ struct PluginProperty {
 	double maskUpperBoundMarginAmpDb = -25.0;
 };
 
-} // namespace LiveBackgroundRemovalLite
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter

--- a/src/LiveBackgroundRemovalLite/Filter/RenderingContext.cpp
+++ b/src/LiveBackgroundRemovalLite/Filter/RenderingContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Live Background Removal Lite
+ * Live Background Removal Lite - Filter Module
  * Copyright (C) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This program is free software; you can redistribute it and/or modify
@@ -22,8 +22,7 @@ using namespace KaitoTokyo::Memory;
 using namespace KaitoTokyo::SelfieSegmenter;
 using namespace KaitoTokyo::TaskQueue;
 
-namespace KaitoTokyo {
-namespace LiveBackgroundRemovalLite {
+namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter {
 
 namespace {
 
@@ -359,5 +358,4 @@ void RenderingContext::applyPluginProperty(const PluginProperty &pluginProperty)
 	logger_.info("Mask upper bound margin set to {}", newMaskUpperBoundMargin);
 }
 
-} // namespace LiveBackgroundRemovalLite
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter

--- a/src/LiveBackgroundRemovalLite/Filter/RenderingContext.hpp
+++ b/src/LiveBackgroundRemovalLite/Filter/RenderingContext.hpp
@@ -1,5 +1,5 @@
 /*
- * Live Background Removal Lite
+ * Live Background Removal Lite - Filter Module
  * Copyright (C) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This program is free software; you can redistribute it and/or modify
@@ -40,8 +40,7 @@
 #include "PluginConfig.hpp"
 #include "PluginProperty.hpp"
 
-namespace KaitoTokyo {
-namespace LiveBackgroundRemovalLite {
+namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter {
 
 struct RenderingContextRegion {
 	std::uint32_t x;
@@ -153,5 +152,4 @@ private:
 	vec4 blackColor_ = {0.0f, 0.0f, 0.0f, 1.0f};
 };
 
-} // namespace LiveBackgroundRemovalLite
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::LiveBackgroundRemovalLite::Filter

--- a/src/Memory/AlignedMemoryResource.hpp
+++ b/src/Memory/AlignedMemoryResource.hpp
@@ -15,8 +15,7 @@
 
 #include <memory_resource>
 
-namespace KaitoTokyo {
-namespace Memory {
+namespace KaitoTokyo::Memory {
 
 class AlignedMemoryResource : public std::pmr::memory_resource {
 public:
@@ -63,5 +62,4 @@ private:
 	std::pmr::memory_resource *upstream_;
 };
 
-} // namespace Memory
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::Memory

--- a/src/Memory/MemoryBlockPool.hpp
+++ b/src/Memory/MemoryBlockPool.hpp
@@ -21,8 +21,7 @@
 
 #include "AlignedMemoryResource.hpp"
 
-namespace KaitoTokyo {
-namespace Memory {
+namespace KaitoTokyo::Memory {
 
 /**
  * @class MemoryBlockPool
@@ -144,5 +143,4 @@ private:
 	mutable std::mutex poolMutex_;
 };
 
-} // namespace Memory
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::Memory

--- a/src/SelfieSegmenter/ISelfieSegmenter.hpp
+++ b/src/SelfieSegmenter/ISelfieSegmenter.hpp
@@ -1,5 +1,5 @@
 /*
- * SelfieSegmenter
+ * KaitoTokyo SelfieSegmenter Library
  * Copyright (c) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This software is licensed under the MIT License.
@@ -16,8 +16,7 @@
 #include <mutex>
 #include <vector>
 
-namespace KaitoTokyo {
-namespace SelfieSegmenter {
+namespace KaitoTokyo::SelfieSegmenter {
 
 class ISelfieSegmenter {
 protected:
@@ -40,5 +39,4 @@ public:
 	ISelfieSegmenter &operator=(ISelfieSegmenter &&) = delete;
 };
 
-} // namespace SelfieSegmenter
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::SelfieSegmenter

--- a/src/SelfieSegmenter/MaskBuffer.hpp
+++ b/src/SelfieSegmenter/MaskBuffer.hpp
@@ -1,5 +1,5 @@
 /*
- * SelfieSegmenter
+ * KaitoTokyo SelfieSegmenter Library
  * Copyright (c) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This software is licensed under the MIT License.
@@ -18,8 +18,7 @@
 
 #include <AlignedMemoryResource.hpp>
 
-namespace KaitoTokyo {
-namespace SelfieSegmenter {
+namespace KaitoTokyo::SelfieSegmenter {
 
 class MaskBuffer {
 public:
@@ -69,5 +68,4 @@ private:
 	mutable std::mutex bufferMutex_;
 };
 
-} // namespace SelfieSegmenter
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::SelfieSegmenter

--- a/src/SelfieSegmenter/NcnnSelfieSegmenter.hpp
+++ b/src/SelfieSegmenter/NcnnSelfieSegmenter.hpp
@@ -1,5 +1,5 @@
 /*
- * SelfieSegmenter
+ * KaitoTokyo SelfieSegmenter Library
  * Copyright (c) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This software is licensed under the MIT License.
@@ -27,8 +27,7 @@
 #include "MaskBuffer.hpp"
 #include "ShapeConverter.hpp"
 
-namespace KaitoTokyo {
-namespace SelfieSegmenter {
+namespace KaitoTokyo::SelfieSegmenter {
 
 class NcnnSelfieSegmenter final : public ISelfieSegmenter {
 public:
@@ -98,5 +97,4 @@ private:
 	ncnn::Mat outputMat_;
 };
 
-} // namespace SelfieSegmenter
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::SelfieSegmenter

--- a/src/SelfieSegmenter/NullSelfieSegmenter.hpp
+++ b/src/SelfieSegmenter/NullSelfieSegmenter.hpp
@@ -1,5 +1,5 @@
 /*
- * SelfieSegmenter
+ * KaitoTokyo SelfieSegmenter Library
  * Copyright (c) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This software is licensed under the MIT License.
@@ -12,8 +12,7 @@
 #include "ISelfieSegmenter.hpp"
 #include "MaskBuffer.hpp"
 
-namespace KaitoTokyo {
-namespace SelfieSegmenter {
+namespace KaitoTokyo::SelfieSegmenter {
 
 class NullSelfieSegmenter final : public ISelfieSegmenter {
 public:
@@ -42,5 +41,4 @@ private:
 	MaskBuffer maskBuffer_;
 };
 
-} // namespace SelfieSegmenter
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::SelfieSegmenter

--- a/src/SelfieSegmenter/ShapeConverter.cpp
+++ b/src/SelfieSegmenter/ShapeConverter.cpp
@@ -1,5 +1,5 @@
 /*
- * SelfieSegmenter
+ * KaitoTokyo SelfieSegmenter Library
  * Copyright (c) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This software is licensed under the MIT License.
@@ -29,8 +29,7 @@
 #endif // __ARM_NEON
 #endif // defined(_M_ARM64) || defined(__aarch64__)
 
-namespace KaitoTokyo {
-namespace SelfieSegmenter {
+namespace KaitoTokyo::SelfieSegmenter {
 
 namespace {
 
@@ -634,5 +633,4 @@ void copy_float32_to_r8(std::uint8_t *dst, const float *src, std::size_t pixelCo
 #endif
 }
 
-} // namespace SelfieSegmenter
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::SelfieSegmenter

--- a/src/SelfieSegmenter/ShapeConverter.hpp
+++ b/src/SelfieSegmenter/ShapeConverter.hpp
@@ -1,5 +1,5 @@
 /*
- * SelfieSegmenter
+ * KaitoTokyo SelfieSegmenter Library
  * Copyright (c) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This software is licensed under the MIT License.
@@ -12,13 +12,11 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace KaitoTokyo {
-namespace SelfieSegmenter {
+namespace KaitoTokyo::SelfieSegmenter {
 
 void copy_r8_bgra_to_float_chw(float *rChannel, float *gChannel, float *bChannel, const std::uint8_t *bgra_data,
 			       const std::size_t pixelCount);
 
 void copy_float32_to_r8(std::uint8_t *dst, const float *src, std::size_t pixelCount);
 
-} // namespace SelfieSegmenter
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::SelfieSegmenter

--- a/src/TaskQueue/ThrottledTaskQueue.hpp
+++ b/src/TaskQueue/ThrottledTaskQueue.hpp
@@ -1,5 +1,5 @@
 /*
- * TaskQueue
+ * KaitoTokyo TaskQueue Library
  * Copyright (c) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This software is licensed under the MIT License.
@@ -23,8 +23,7 @@
 
 #include <ILogger.hpp>
 
-namespace KaitoTokyo {
-namespace TaskQueue {
+namespace KaitoTokyo::TaskQueue {
 
 /**
  * @brief A self-contained thread queue for executing cancellable tasks with a limit.
@@ -212,5 +211,4 @@ private:
 	std::thread worker_;
 };
 
-} // namespace TaskQueue
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::TaskQueue

--- a/src/UpdateChecker/UpdateChecker.hpp
+++ b/src/UpdateChecker/UpdateChecker.hpp
@@ -1,5 +1,5 @@
 /*
- * UpdateChecker
+ * KaitoTokyo UpdateChecker Library
  * Copyright (c) 2025 Kaito Udagawa umireon@kaito.tokyo
  *
  * This software is licensed under the MIT License.
@@ -15,8 +15,7 @@
 
 #include <curl/curl.h>
 
-namespace KaitoTokyo {
-namespace UpdateChecker {
+namespace KaitoTokyo::UpdateChecker {
 
 inline size_t writeCallback(void *contents, size_t size, size_t nmemb, void *userp)
 {
@@ -97,5 +96,4 @@ inline std::string fetchLatestVersion(const std::string &url)
 	return result;
 }
 
-} // namespace UpdateChecker
-} // namespace KaitoTokyo
+} // namespace KaitoTokyo::UpdateChecker

--- a/src/plugin-main.cpp
+++ b/src/plugin-main.cpp
@@ -14,7 +14,7 @@
 
 #include <obs-module.h>
 
-#include "Core/MainPluginContext.h"
+#include <MainPluginContext.h>
 #include "plugin-support.h"
 
 OBS_DECLARE_MODULE()


### PR DESCRIPTION
This pull request restructures the project to improve modularity and clarity by moving the filter-related code into a dedicated `Filter` module under `LiveBackgroundRemovalLite`, and updates the CMake configuration accordingly. It also modernizes C++ namespace usage throughout the codebase for conciseness and consistency.

**Project structure and build system changes:**

* Moved filter implementation files from the `Core` directory to `LiveBackgroundRemovalLite/Filter`, renaming files and updating all references to use the new location and module name. The `Filter` module is now added as a subdirectory in CMake, and the build configuration has been updated to link against the correct targets and dependencies. (`src/LiveBackgroundRemovalLite/Filter/CMakeLists.txt` renamed from `src/Core/CMakeLists.txt`, `src/CMakeLists.txt`, `src/LiveBackgroundRemovalLite/CMakeLists.txt`, [[1]](diffhunk://#diff-072bb07cf3ee574c72269761e7855ff59ccf287fc196fb8cdc9e26dd68129f01L1-R8) [[2]](diffhunk://#diff-072bb07cf3ee574c72269761e7855ff59ccf287fc196fb8cdc9e26dd68129f01L21-R26) [[3]](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4L12-R12) [[4]](diffhunk://#diff-428e5ee2bbe6526f37810809622541299bf40f254c98ce2de172ab1582b5ab3dR1)
* Updated the top-level `CMakeLists.txt` to link the main plugin against the new `Filter` module and OBS libraries, and to use the C++ source file for the plugin entry point.

**Namespace modernization:**

* Replaced nested namespace blocks (e.g., `namespace KaitoTokyo { namespace BridgeUtils {`) with the modern C++17 inline namespace syntax (e.g., `namespace KaitoTokyo::BridgeUtils {`) across all relevant headers and source files for improved readability and maintainability. [[1]](diffhunk://#diff-414119f2a2a016953edb5de096f35ca34e9c786d3155854d84f967329fd2f509L29-R29) [[2]](diffhunk://#diff-414119f2a2a016953edb5de096f35ca34e9c786d3155854d84f967329fd2f509L347-R346) [[3]](diffhunk://#diff-67c469262f1618af3b80244070e6ce58aea33c3a7654f72e0714c5b009902d28L28-R28) [[4]](diffhunk://#diff-67c469262f1618af3b80244070e6ce58aea33c3a7654f72e0714c5b009902d28L254-R253) [[5]](diffhunk://#diff-7a7584aed12a14e413dbe796951225294c660dac5abb1b65b78e60d6c7953223L25-R25) [[6]](diffhunk://#diff-7a7584aed12a14e413dbe796951225294c660dac5abb1b65b78e60d6c7953223L77-R76) [[7]](diffhunk://#diff-728b5cc3a39d2780db4cf9fbbc22125ff2c3a0b4462bc764cbd18404a7e330ffL23-R23) [[8]](diffhunk://#diff-728b5cc3a39d2780db4cf9fbbc22125ff2c3a0b4462bc764cbd18404a7e330ffL140-R139) [[9]](diffhunk://#diff-a61f6385c4b056ed5a64f2ad4d452936ea433660443e357c4eeb37dac83376eaL88-R88) [[10]](diffhunk://#diff-a61f6385c4b056ed5a64f2ad4d452936ea433660443e357c4eeb37dac83376eaL416-R415) [[11]](diffhunk://#diff-92d250fefe49035b4527d1efa127d6b3a504aaa19c151a6b59b8374b9dc2fadfL28-R28) [[12]](diffhunk://#diff-92d250fefe49035b4527d1efa127d6b3a504aaa19c151a6b59b8374b9dc2fadfL72-R71) [[13]](diffhunk://#diff-eb7b8f6b1b18d2ddf0bb2af7183724a0db79a611b9fa205845890682a3fc3b44L26-R26) [[14]](diffhunk://#diff-eb7b8f6b1b18d2ddf0bb2af7183724a0db79a611b9fa205845890682a3fc3b44L436-R435) [[15]](diffhunk://#diff-b65c0c136880ae33293ef5a82e083f6185c6f1daa370ae9328b998d3ef6a5625L36-R36) [[16]](diffhunk://#diff-b65c0c136880ae33293ef5a82e083f6185c6f1daa370ae9328b998d3ef6a5625L399-R398) [[17]](diffhunk://#diff-33ddc0073b7f80e6dc5cbcb2cc3e01a1e00ecd2eaaa74e2037256255ab9bf656L35-R35) [[18]](diffhunk://#diff-33ddc0073b7f80e6dc5cbcb2cc3e01a1e00ecd2eaaa74e2037256255ab9bf656L93-R92) [[19]](diffhunk://#diff-997e0b1721c3eb8a9600a2420b0ad20b49ba3bf0b44bdf3477782015040d8890L33-R33) [[20]](diffhunk://#diff-a1e0a7d05d1247407452ff8fef99aed8f3d91a5d5bcb75e638aff640638bd8c5L23-R23) [[21]](diffhunk://#diff-a1e0a7d05d1247407452ff8fef99aed8f3d91a5d5bcb75e638aff640638bd8c5L78-R77) [[22]](diffhunk://#diff-91383aaf20c29c822dbf3e40585b89063ce0a4ba15f5576d63cf046eb6acee95L17-R17) [[23]](diffhunk://#diff-91383aaf20c29c822dbf3e40585b89063ce0a4ba15f5576d63cf046eb6acee95L46-R45) [[24]](diffhunk://#diff-828dc7c098fa08d3355850c583afef37b344c8dbf2fa0e2a5526c75109c55d2cL25-R25)

**Code and documentation updates:**

* Updated file headers and copyright notices to reflect the new module and file locations, ensuring accurate attribution and clarity. [[1]](diffhunk://#diff-a61f6385c4b056ed5a64f2ad4d452936ea433660443e357c4eeb37dac83376eaL2-R2) [[2]](diffhunk://#diff-92d250fefe49035b4527d1efa127d6b3a504aaa19c151a6b59b8374b9dc2fadfL2-R2) [[3]](diffhunk://#diff-eb7b8f6b1b18d2ddf0bb2af7183724a0db79a611b9fa205845890682a3fc3b44L2-R2) [[4]](diffhunk://#diff-b65c0c136880ae33293ef5a82e083f6185c6f1daa370ae9328b998d3ef6a5625L2-R2) [[5]](diffhunk://#diff-33ddc0073b7f80e6dc5cbcb2cc3e01a1e00ecd2eaaa74e2037256255ab9bf656L2-R2) [[6]](diffhunk://#diff-997e0b1721c3eb8a9600a2420b0ad20b49ba3bf0b44bdf3477782015040d8890L2-R2) [[7]](diffhunk://#diff-a1e0a7d05d1247407452ff8fef99aed8f3d91a5d5bcb75e638aff640638bd8c5L2-R2) [[8]](diffhunk://#diff-91383aaf20c29c822dbf3e40585b89063ce0a4ba15f5576d63cf046eb6acee95L2-R2) [[9]](diffhunk://#diff-828dc7c098fa08d3355850c583afef37b344c8dbf2fa0e2a5526c75109c55d2cL2-R2)

These changes improve the maintainability and scalability of the codebase by clearly separating filter functionality and adopting modern C++ practices.Moved all Core module files to src/LiveBackgroundRemovalLite/Filter, renamed the static library to _Filter, and updated CMake configuration accordingly. Unified nested namespaces to use C++17 inline namespace syntax throughout the codebase. Updated copyright headers and include paths for consistency. Changed plugin entry point from C to C++.