### PR TITLE
Rename japanese name

### DIFF
--- a/data/locale/ja-JP.ini
+++ b/data/locale/ja-JP.ini
@@ -1,4 +1,4 @@
-pluginName="Live背景除去Lite"
+pluginName="Live Background Removal Lite"
 
 updateCheckerChecking="更新を確認中..."
 updateCheckerPluginIsLatest="プラグインは最新の状態です。"


### PR DESCRIPTION
This pull request updates the plugin name in the Japanese locale file to its English equivalent for consistency.

Localization update:

* Changed the `pluginName` value in `data/locale/ja-JP.ini` from "Live背景除去Lite" to "Live Background Removal Lite".