### PR TITLE
Update GlobalContext.hpp

### DIFF
--- a/src/LiveBackgroundRemovalLite/Global/GlobalContext.hpp
+++ b/src/LiveBackgroundRemovalLite/Global/GlobalContext.hpp
@@ -52,7 +52,7 @@ public:
 	std::string getLatestVersion() const;
 
 private:
-	using TaskStorage = Async::TaskStorage<>;
+	using TaskStorage = Async::TaskStorage<32768>;
 
 	const std::shared_ptr<PluginConfig> pluginConfig_;
 


### PR DESCRIPTION
This pull request makes a targeted update to the `GlobalContext` class by specifying a fixed template argument for the `TaskStorage` type alias. This change sets the storage capacity explicitly, which can help manage memory usage and task handling more predictably. No other changes are included.

- Set the `TaskStorage` type alias in `GlobalContext` to use a fixed size of 32,768, replacing the default template argument.