### PR TITLE
Set Window Modality

### DIFF
--- a/src/LiveBackgroundRemovalLite/MainFilter/MainFilterContext.cpp
+++ b/src/LiveBackgroundRemovalLite/MainFilter/MainFilterContext.cpp
@@ -18,7 +18,7 @@
 #include <stdexcept>
 #include <thread>
 
-#include <QMainWindow>
+#include <QApplication>
 
 #include <obs-module.h>
 #include <obs-frontend-api.h>
@@ -141,8 +141,7 @@ obs_properties_t *MainFilterContext::getProperties()
 				if (this_->debugWindow_) {
 					windowToShow = this_->debugWindow_;
 				} else {
-					auto parent = static_cast<QWidget *>(obs_frontend_get_main_window());
-					auto newDebugWindow = new DebugWindow(this_->weak_from_this(), parent);
+					auto newDebugWindow = new DebugWindow(this_->weak_from_this(), QApplication::activeWindow());
 
 					newDebugWindow->setAttribute(Qt::WA_DeleteOnClose);
 
@@ -219,15 +218,12 @@ obs_properties_t *MainFilterContext::getProperties()
 	obs_properties_add_button2(
 		props, "openGlobalConfigDialog", obs_module_text("openGlobalConfigDialog"),
 		[](obs_properties_t *, obs_property_t *, void *data) {
-			QMainWindow *mainWindow = static_cast<QMainWindow *>(obs_frontend_get_main_window());
-			if (!mainWindow)
-				return false;
-
 			MainFilterContext *self = static_cast<MainFilterContext *>(data);
 			if (!self)
 				return false;
 
-			Global::PluginConfigDialog dialog(self->pluginConfig_, mainWindow);
+			Global::PluginConfigDialog dialog(self->pluginConfig_, QApplication::activeWindow());
+			dialog.setWindowModality(Qt::WindowModal);
 			dialog.exec();
 			return false;
 		},


### PR DESCRIPTION
This pull request updates the handling of parent windows in the `MainFilterContext` to use `QApplication::activeWindow()` instead of directly referencing the OBS main window. This change improves compatibility and ensures dialogs and windows are parented to the currently active window, which is more robust in multi-window scenarios.

**Qt parent window handling improvements:**

* Replaced all uses of `obs_frontend_get_main_window()` and explicit casting to `QMainWindow` with `QApplication::activeWindow()` when creating new dialogs and windows, ensuring correct parenting and improved compatibility. [[1]](diffhunk://#diff-df5b2266c80c1b923a448c4a1528ce54d77f28c42afe26f70d2a576872978a3bL21-R21) [[2]](diffhunk://#diff-df5b2266c80c1b923a448c4a1528ce54d77f28c42afe26f70d2a576872978a3bL144-R144) [[3]](diffhunk://#diff-df5b2266c80c1b923a448c4a1528ce54d77f28c42afe26f70d2a576872978a3bL222-R226)
* Set the global config dialog's window modality to `Qt::WindowModal` to ensure it behaves modally relative to its parent window.