### PR TITLE
Disable BUILD_TESTING by default and clean up CMake presets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ include(init)
 
 project(${PLUGIN_NAME} VERSION ${PLUGIN_VERSION} LANGUAGES C CXX)
 
-option(BUILD_TESTING "Build test cases" ON)
+option(BUILD_TESTING "Build test cases" OFF)
 option(ENABLE_ASAN "Enable Address Sanitizer" OFF)
 option(ENABLE_UBSAN "Enable Undefined Behavior Sanitizer" OFF)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,9 +22,7 @@
         "CMAKE_OSX_DEPLOYMENT_TARGET": "12.0",
         "CMAKE_OSX_ARCHITECTURES": "arm64;x86_64",
         "VCPKG_TARGET_TRIPLET": "universal-osx-obs",
-        "BUILD_TESTING": true,
-        "ENABLE_ASAN": false,
-        "ENABLE_UBSAN": false
+        "BUILD_TESTING": true
       }
     },
     {
@@ -35,7 +33,6 @@
       "binaryDir": "${sourceDir}/build_macos_dev",
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "universal-osx-obs-asan",
-        "BUILD_TESTING": true,
         "ENABLE_ASAN": true,
         "ENABLE_UBSAN": true
       }
@@ -46,9 +43,7 @@
       "displayName": "macOS (Production)",
       "description": "Build universal binary for macOS 12.0+ (Production)",
       "cacheVariables": {
-        "BUILD_TESTING": false,
-        "ENABLE_ASAN": false,
-        "ENABLE_UBSAN": false
+        "BUILD_TESTING": false
       }
     },
     {
@@ -66,9 +61,7 @@
       "warnings": { "dev": true, "deprecated": true },
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "x64-windows-static-md-obs",
-        "BUILD_TESTING": true,
-        "ENABLE_ASAN": false,
-        "ENABLE_UBSAN": false
+        "BUILD_TESTING": true
       }
     },
     {
@@ -77,9 +70,7 @@
       "displayName": "Windows x64 (Production)",
       "description": "Build x64 binary for Windows (Production)",
       "cacheVariables": {
-        "BUILD_TESTING": false,
-        "ENABLE_ASAN": false,
-        "ENABLE_UBSAN": false
+        "BUILD_TESTING": false
       }
     },
     {
@@ -98,9 +89,7 @@
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_INSTALL_LIBDIR": "lib/CMAKE_SYSTEM_PROCESSOR-linux-gnu",
         "VCPKG_TARGET_TRIPLET": "x64-linux-obs",
-        "BUILD_TESTING": true,
-        "ENABLE_ASAN": false,
-        "ENABLE_UBSAN": false
+        "BUILD_TESTING": true
       }
     },
     {
@@ -110,9 +99,7 @@
       "description": "Build x86_64 binary for Ubuntu (Production)",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-        "BUILD_TESTING": false,
-        "ENABLE_ASAN": false,
-        "ENABLE_UBSAN": false
+        "BUILD_TESTING": false
       }
     }
   ],


### PR DESCRIPTION
This pull request updates the build configuration to simplify and clarify how test builds and sanitizers are enabled across different platforms. The main change is to only specify the `BUILD_TESTING` option in CMake presets, removing redundant sanitizer options from most presets. The default for `BUILD_TESTING` is also changed to OFF in the main `CMakeLists.txt`.

Build configuration simplification:

* Changed the default value of the `BUILD_TESTING` option in `CMakeLists.txt` from ON to OFF, so tests are not built by default unless explicitly enabled.
* Updated all platform-specific entries in `CMakePresets.json` to only specify `BUILD_TESTING`, removing `ENABLE_ASAN` and `ENABLE_UBSAN` except where sanitizers are explicitly needed (e.g., macOS dev ASAN/UBSAN build). [[1]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L25-R25) [[2]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L38) [[3]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L49-R46) [[4]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L69-R64) [[5]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L80-R73) [[6]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L101-R92) [[7]](diffhunk://#diff-1712b235e02bd4a3ad866fe26447a6dc5c1b449faeea513f449d244d46d03cf5L113-R102)Set BUILD_TESTING to OFF by default in CMakeLists.txt. Removed redundant ENABLE_ASAN and ENABLE_UBSAN cache variables from CMakePresets.json to simplify configuration.